### PR TITLE
fix(setup): BUILD pipeline doesn't trigger (triggers disabled)

### DIFF
--- a/setup.ps1
+++ b/setup.ps1
@@ -1447,20 +1447,27 @@ function Ensure-AzDoYamlPipelineDefinition {
 
         # Use Invoke-VSTeamRequest since VSTeam build definition commands require JSON files
         $body = @{
-            name       = $DefinitionName
-            path       = $FolderPath
-            type       = 'build'
-            queue      = @{ id = $QueueId }
-            repository = @{
+            name        = $DefinitionName
+            path        = $FolderPath
+            type        = 'build'
+            queueStatus = 'enabled'
+            queue       = @{ id = $QueueId }
+            repository  = @{
                 id            = $Repository.Id
                 name          = $Repository.Name
                 type          = 'TfsGit'
                 defaultBranch = $repoBranch
             }
-            process    = @{
+            process     = @{
                 type         = 2
                 yamlFilename = $YamlPath
             }
+            triggers    = @(
+                @{
+                    settingsSourceType = 2
+                    triggerType        = 'continuousIntegration'
+                }
+            )
         }
 
         $resource = "build/definitions"


### PR DESCRIPTION
This pull request updates `setup.ps1` to improve the configuration of the Azure DevOps YAML pipeline definitions. The main changes ensure that pipelines are enabled by default with the triggers loaded from the YAML files.

Pipeline configuration improvements:

* Added `queueStatus = 'enabled'` to the pipeline definition so new pipelines are enabled by default.
* Added a `triggers` section to the pipeline definition, configuring a continuous integration trigger with `settingsSourceType = 2` and `triggerType = 'continuousIntegration'`.