### PR TITLE
feat: optional solution checker run during BUILD with configuable threshold and suppressions etc

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,11 @@ on:
         type: string
         default: ''
         description: 'Optional source branch name used for downstream repository_dispatch payloads'
+      environment-name:
+        required: false
+        type: string
+        default: ''
+        description: 'Optional environment name to use for pre-build Dataverse connect and solution validation.'
       timeout-minutes:
         required: false
         type: number
@@ -48,9 +53,15 @@ jobs:
     permissions:
       contents: write  # push git tag
       actions: write   # upload artifacts
+      id-token: write  # optional OIDC token for Dataverse connect
     outputs:
       run-id: ${{ github.run_id }}
       run-name: ${{ steps.build-number.outputs.run_name }}
+    env:
+      AZURE_CLIENT_ID:     ${{ vars.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID:     ${{ vars.AZURE_TENANT_ID }}
+      AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+      DATAVERSE_URL:       ${{ vars.DATAVERSE_URL }}
 
     steps:
       - name: Checkout source code
@@ -148,11 +159,195 @@ jobs:
           Write-Host "Exact build name: $buildNumber"
           Write-Host "Build number: $buildNumber"
 
-      - name: Install Dependencies and Build
+      - name: Resolve prefixed repo variables and secrets
+        if: inputs.environment-name != ''
+        shell: pwsh
+        env:
+          ALL_REPO_VARS_JSON: ${{ toJSON(vars) }}
+          ALL_REPO_SECRETS_JSON: ${{ toJSON(secrets) }}
+          RESOLVED_ENVIRONMENT_NAME: ${{ inputs.environment-name }}
+        run: |
+          function ConvertTo-HashtableSafe([string]$jsonText) {
+            if ([string]::IsNullOrWhiteSpace($jsonText)) {
+              return @{}
+            }
+
+            try {
+              $result = $jsonText | ConvertFrom-Json -AsHashtable
+              if ($null -eq $result) {
+                return @{}
+              }
+
+              return $result
+            } catch {
+              Write-Warning "Could not parse JSON context for prefixed mapping. Continuing without it."
+              return @{}
+            }
+          }
+
+          function Write-GitHubEnv([string]$name, [string]$value) {
+            $delimiter = "EOF_$([Guid]::NewGuid().ToString('N'))"
+            Add-Content -Path $env:GITHUB_ENV -Value "$name<<$delimiter"
+            Add-Content -Path $env:GITHUB_ENV -Value $value
+            Add-Content -Path $env:GITHUB_ENV -Value $delimiter
+          }
+
+          function Get-PrefixFromEnvironment([string]$environmentName) {
+            if ([string]::IsNullOrWhiteSpace($environmentName)) {
+              return ''
+            }
+
+            $normalized = ($environmentName.Trim().ToUpperInvariant() -replace '[^A-Z0-9]+', '_').Trim('_')
+            if ([string]::IsNullOrWhiteSpace($normalized)) {
+              return ''
+            }
+
+            return "$normalized`_"
+          }
+
+          $aliasTargets = @{
+            'DATAVERSE_SERVICE_ACCOUNT_UPN' = 'DATAVERSESERVICEACCOUNTUPN'
+            'DATAVERSE_CONN_REFS'           = 'DATAVERSE_CONNECTION_REFS'
+          }
+
+          $derivedPrefix   = Get-PrefixFromEnvironment $env:RESOLVED_ENVIRONMENT_NAME
+          $prefixCandidates = @('PREFIX_')
+          if (-not [string]::IsNullOrWhiteSpace($derivedPrefix) -and $derivedPrefix -ne 'PREFIX_') {
+            $prefixCandidates = @($derivedPrefix) + $prefixCandidates
+          }
+
+          $sources = @(
+            @{ Name = 'secrets';   Data = ConvertTo-HashtableSafe $env:ALL_REPO_SECRETS_JSON; IsSensitive = $true  },
+            @{ Name = 'variables'; Data = ConvertTo-HashtableSafe $env:ALL_REPO_VARS_JSON;    IsSensitive = $false }
+          )
+
+          $setCount = 0
+          foreach ($source in $sources) {
+            foreach ($entry in $source.Data.GetEnumerator()) {
+              $fullName = [string]$entry.Key
+
+              $matchedPrefix = $null
+              foreach ($candidate in $prefixCandidates) {
+                if ($fullName.StartsWith($candidate, [System.StringComparison]::OrdinalIgnoreCase)) {
+                  $matchedPrefix = $candidate
+                  break
+                }
+              }
+
+              if ($null -eq $matchedPrefix) {
+                continue
+              }
+
+              $targetName = $fullName.Substring($matchedPrefix.Length)
+              if ([string]::IsNullOrWhiteSpace($targetName)) {
+                continue
+              }
+
+              $targetNames = @($targetName)
+              if ($aliasTargets.ContainsKey($targetName)) {
+                $targetNames += $aliasTargets[$targetName]
+              }
+
+              $rawValue = $entry.Value
+              if ($null -eq $rawValue) {
+                continue
+              }
+
+              $valueText = if ($rawValue -is [string]) {
+                [string]$rawValue
+              } else {
+                $rawValue | ConvertTo-Json -Compress -Depth 50
+              }
+
+              if ([string]::IsNullOrWhiteSpace($valueText)) {
+                continue
+              }
+
+              foreach ($name in ($targetNames | Select-Object -Unique)) {
+                if (-not [string]::IsNullOrWhiteSpace([System.Environment]::GetEnvironmentVariable($name))) {
+                  continue
+                }
+
+                [System.Environment]::SetEnvironmentVariable($name, $valueText)
+                Write-GitHubEnv -name $name -value $valueText
+                if ($source.IsSensitive) {
+                  Write-Output "::add-mask::$valueText"
+                }
+
+                $setCount++
+                Write-Host "Mapped prefixed $($source.Name) '$fullName' -> '$name'"
+              }
+            }
+          }
+
+          Write-Host "Prefixed mapping complete. Variables set: $setCount"
+
+      - name: Validate authentication inputs
+        if: inputs.environment-name != ''
+        shell: pwsh
+        run: |
+          if ([string]::IsNullOrWhiteSpace($env:AZURE_CLIENT_ID)) {
+            throw "AZURE_CLIENT_ID is required. Set GitHub environment variable AZURE_CLIENT_ID or provide a prefixed repo-level secret/variable."
+          }
+
+          if ([string]::IsNullOrWhiteSpace($env:AZURE_TENANT_ID)) {
+            throw "AZURE_TENANT_ID is required. Set GitHub environment variable AZURE_TENANT_ID or provide a prefixed repo-level secret/variable."
+          }
+
+          $tenant = $env:AZURE_TENANT_ID.Trim()
+          $isGuid = $tenant -match '^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$'
+          $isDns  = $tenant -match '^[A-Za-z0-9][A-Za-z0-9.-]*\.[A-Za-z]{2,}$'
+          if (-not ($isGuid -or $isDns)) {
+            throw "AZURE_TENANT_ID value '$tenant' is invalid. Use a tenant GUID or tenant domain (for example, contoso.onmicrosoft.com)."
+          }
+
+          if ([string]::IsNullOrWhiteSpace($env:DATAVERSE_URL)) {
+            throw "DATAVERSE_URL is required. Set GitHub environment variable DATAVERSE_URL or provide a prefixed repo-level variable."
+          }
+
+      - name: Set up Workload Identity Federation (if no client secret)
+        if: inputs.environment-name != ''
+        shell: pwsh
+        run: |
+          if (-not [string]::IsNullOrWhiteSpace($env:AZURE_CLIENT_SECRET)) {
+            Write-Host "AZURE_CLIENT_SECRET is set; skipping OIDC token file setup."
+            exit 0
+          }
+
+          if ([string]::IsNullOrWhiteSpace($env:ACTIONS_ID_TOKEN_REQUEST_URL) -or [string]::IsNullOrWhiteSpace($env:ACTIONS_ID_TOKEN_REQUEST_TOKEN)) {
+            throw "OIDC token request variables are unavailable. Ensure 'permissions: id-token: write' is granted to this job."
+          }
+
+          $audience = 'api://AzureADTokenExchange'
+          $requestUrl = "$($env:ACTIONS_ID_TOKEN_REQUEST_URL)&audience=$([System.Uri]::EscapeDataString($audience))"
+          $headers = @{ Authorization = "bearer $($env:ACTIONS_ID_TOKEN_REQUEST_TOKEN)" }
+          $response = Invoke-RestMethod -Method Get -Uri $requestUrl -Headers $headers
+          $token = [string]$response.value
+          if ([string]::IsNullOrWhiteSpace($token)) {
+            throw "Received an empty OIDC token from GitHub."
+          }
+
+          $tokenPath = Join-Path $env:RUNNER_TEMP 'github-oidc-token.txt'
+          Set-Content -LiteralPath $tokenPath -Value $token -NoNewline
+
+          "AZURE_FEDERATED_TOKEN_FILE=$tokenPath" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          Write-Host "Configured AZURE_FEDERATED_TOKEN_FILE for DefaultAzureCredential."
+
+      - name: Connect to Dataverse (optional)
+        if: inputs.environment-name != ''
         shell: pwsh
         working-directory: ${{ github.workspace }}/self
         run: |
           & "${{ github.workspace }}/alm/pipelines/scripts/installdependencies.ps1"
+          & "${{ github.workspace }}/alm/pipelines/scripts/connect.ps1" -Url $env:DATAVERSE_URL
+
+      - name: Install Dependencies and Build
+        shell: pwsh
+        working-directory: ${{ github.workspace }}/self
+        run: |
+          if ('${{ inputs.environment-name }}' -eq '') {
+            & "${{ github.workspace }}/alm/pipelines/scripts/installdependencies.ps1"
+          }
           & "${{ github.workspace }}/alm/pipelines/scripts/build.ps1" `
             -SourceDirectory "${{ github.workspace }}/self" `
             -ArtifactStagingDirectory "${{ github.workspace }}/artifacts"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,9 @@ jobs:
   build:
     runs-on: windows-latest
     timeout-minutes: ${{ inputs.timeout-minutes }}
+    environment:
+      name: ${{ inputs.environment-name }}
+      deployment: false
     permissions:
       contents: write  # push git tag
       actions: write   # upload artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -158,11 +158,22 @@ jobs:
             -ArtifactStagingDirectory "${{ github.workspace }}/artifacts"
 
       - name: Upload build artifacts
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: artifacts
           path: ${{ github.workspace }}/artifacts/
           retention-days: 90
+          if-no-files-found: warn
+
+      - name: Upload solution check report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: solution-check-report
+          path: ${{ github.workspace }}/artifacts/solution-check/
+          retention-days: 90
+          if-no-files-found: ignore
 
       - name: Tag source with build version
         shell: pwsh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -336,20 +336,13 @@ jobs:
           "AZURE_FEDERATED_TOKEN_FILE=$tokenPath" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
           Write-Host "Configured AZURE_FEDERATED_TOKEN_FILE for DefaultAzureCredential."
 
-      - name: Connect to Dataverse (optional)
-        if: inputs.environment-name != ''
-        shell: pwsh
-        working-directory: ${{ github.workspace }}/self
-        run: |
-          & "${{ github.workspace }}/alm/pipelines/scripts/installdependencies.ps1"
-          & "${{ github.workspace }}/alm/pipelines/scripts/connect.ps1" -Url $env:DATAVERSE_URL
-
       - name: Install Dependencies and Build
         shell: pwsh
         working-directory: ${{ github.workspace }}/self
         run: |
-          if ('${{ inputs.environment-name }}' -eq '') {
-            & "${{ github.workspace }}/alm/pipelines/scripts/installdependencies.ps1"
+          & "${{ github.workspace }}/alm/pipelines/scripts/installdependencies.ps1"
+          if ('${{ inputs.environment-name }}' -ne '') {
+            & "${{ github.workspace }}/alm/pipelines/scripts/connect.ps1" -Url $env:DATAVERSE_URL
           }
           & "${{ github.workspace }}/alm/pipelines/scripts/build.ps1" `
             -SourceDirectory "${{ github.workspace }}/self" `

--- a/alm-config-defaults.psd1
+++ b/alm-config-defaults.psd1
@@ -10,4 +10,31 @@
     # Timeout in seconds for each solution import operation.
     # Increase this value if solution imports time out in large or complex environments.
     importTimeoutSeconds = 10800
+
+    # PAC solution check configuration used during BUILD.
+    # Set enabled = $true globally or per-solution to activate checks.
+    solutionCheck = @{
+        enabled = $false
+
+        # Geographic region for solution checker service.
+        geo = 'Europe'
+
+        # Build fails when the highest finding severity is >= this threshold.
+        # Supported: Critical, High, Medium, Low, Informational
+        failThreshold = 'Critical'
+
+        # Rule set to run. Use 'none' to omit --ruleSet.
+        # Examples: 'Solution Checker', 'AppSource Certification', '<GUID>'
+        ruleSet = 'Solution Checker'
+
+        # Globs resolved per solution to concrete files and passed to --excludedFiles.
+        excludedFiles = @()
+
+        # Rule level overrides. Can be a JSON file path, hashtable, or array.
+        # Example item: @{ Id = 'meta-remove-dup-reg'; OverrideLevel = 'Medium' }
+        ruleLevelOverride = @()
+
+        # Maximum number of solutions to check in parallel.
+        maxParallel = 4
+    }
 }

--- a/copy-to-your-repo/.github/workflows/BUILD.yml
+++ b/copy-to-your-repo/.github/workflows/BUILD.yml
@@ -33,3 +33,4 @@ jobs:
     permissions:
       contents: write
       actions: write
+      id-token: write

--- a/copy-to-your-repo/.github/workflows/BUILD.yml
+++ b/copy-to-your-repo/.github/workflows/BUILD.yml
@@ -19,10 +19,6 @@ on:
 
 jobs:
   build:
-    # Optional: uncomment to associate BUILD with a GitHub environment.
-    # environment:
-    #   name: Dev-main
-    #   deployment: false
     uses: ALM4Dataverse/ALM4Dataverse/.github/workflows/build.yml@stable
     with:
       build-name: ${{ format('{0}-{1}-{2}-{3}', github.event.repository.name, (github.event_name == 'repository_dispatch' && github.event.client_payload.branch) || github.ref_name, (github.event_name == 'repository_dispatch' && github.event.client_payload.exported_at) || github.event.head_commit.timestamp || github.event.repository.updated_at || github.run_id, github.run_number) }}

--- a/copy-to-your-repo/.github/workflows/BUILD.yml
+++ b/copy-to-your-repo/.github/workflows/BUILD.yml
@@ -19,11 +19,16 @@ on:
 
 jobs:
   build:
+    # Optional: uncomment to associate BUILD with a GitHub environment.
+    # environment:
+    #   name: Dev-main
+    #   deployment: false
     uses: ALM4Dataverse/ALM4Dataverse/.github/workflows/build.yml@stable
     with:
       build-name: ${{ format('{0}-{1}-{2}-{3}', github.event.repository.name, (github.event_name == 'repository_dispatch' && github.event.client_payload.branch) || github.ref_name, (github.event_name == 'repository_dispatch' && github.event.client_payload.exported_at) || github.event.head_commit.timestamp || github.event.repository.updated_at || github.run_id, github.run_number) }}
       source-branch: ${{ (github.event_name == 'repository_dispatch' && github.event.client_payload.branch) || github.ref_name }}
       source-ref: ${{ (github.event_name == 'repository_dispatch' && github.event.client_payload.sha) || github.sha }}
+      environment-name: ''
       timeout-minutes: 360
     permissions:
       contents: write

--- a/copy-to-your-repo/alm-config.psd1
+++ b/copy-to-your-repo/alm-config.psd1
@@ -24,7 +24,26 @@
     # - serviceAccountUpnConfigKey: (optional) name of the environment configuration key containing
     #   the service account UPN to use when activating processes in this solution.
     #   The default is 'DataverseServiceAccountUpn'
+    # - solutionCheck: (optional) per-solution PAC checker settings merged with global solutionCheck
+    #   settings below. Use enabled = $false to skip checker for a specific solution.
     solutions = @(
+        # Example:
+        # @{
+        #   name = 'ContosoCore'
+        #   solutionCheck = @{
+        #     enabled = $true
+        #     # Use 'none' to omit --ruleSet.
+        #     ruleSet = 'none'
+        #     # Globs are expanded to concrete files before calling pac.
+        #     excludedFiles = @(
+        #       'CanvasApps/**/*.msapp'
+        #     )
+        #     ruleLevelOverride = @(
+        #       @{ Id = 'meta-remove-dup-reg'; OverrideLevel = 'Medium' }
+        #     )
+        #     failThreshold = 'High'
+        #   }
+        # }
     )
 
 
@@ -106,4 +125,31 @@
     # Timeout in seconds for each solution import operation (default: 10800).
     # Increase this value if solution imports time out in large or complex environments.
     # importTimeoutSeconds = 10800
+
+    # PAC solution check settings used by BUILD.
+    # Set enabled = $true globally or per-solution to activate checks.
+    # Per-solution settings are merged with these global settings.
+    #
+    # Supported severities for failThreshold and OverrideLevel:
+    # Critical, High, Medium, Low, Informational.
+    #
+    # ruleSet values:
+    # - 'Solution Checker' (default)
+    # - 'AppSource Certification'
+    # - GUID
+    # - 'none' (do not pass --ruleSet)
+    #
+    # solutionCheck = @{
+    #     enabled = $true
+    #     geo = 'Europe'
+    #     failThreshold = 'Critical'
+    #     ruleSet = 'Solution Checker'
+    #     excludedFiles = @(
+    #         'WebResources/**/*.png'
+    #     )
+    #     ruleLevelOverride = @(
+    #         @{ Id = 'meta-remove-dup-reg'; OverrideLevel = 'Medium' }
+    #     )
+    #     maxParallel = 4
+    # }
 }

--- a/copy-to-your-repo/pipelines/BUILD.yml
+++ b/copy-to-your-repo/pipelines/BUILD.yml
@@ -11,3 +11,6 @@ resources:
 
 stages:
 - template: pipelines/templates/build.yml@ALM4Dataverse
+  parameters:
+    useAlm4DataverseExtension: true
+    buildEnvironmentName: ''

--- a/docs/config/alm-config.md
+++ b/docs/config/alm-config.md
@@ -1,6 +1,6 @@
 # ALM Configuration (alm-config.psd1)
 
-The `alm-config.psd1` file in your repo is the central configuration file for the ALM4Dataverse pipeline system. It defines which solutions to deploy, assets to include, hook scripts to run, and dependencies required for the build, export, and deployment processes.
+The `alm-config.psd1` file in your repo is the central configuration file for the ALM4Dataverse pipeline system. It defines which solutions to deploy, assets to include, hook scripts to run, dependencies required for the build/export/deployment processes, and optional PAC solution validation settings.
 
 ## Location
 
@@ -26,6 +26,7 @@ solutions = @(
 - `name` (required): Unique solution name that matches your solution folder in the source directory
 - `deployUnmanaged` (optional, default: false): Boolean indicating whether to deploy the unmanaged version instead of managed
 - `serviceAccountUpnConfigKey` (optional, default: 'DataverseServiceAccountUpn'): Name of the environment configuration key containing the service account UPN to use when activating processes in this solution
+- `solutionCheck` (optional): Per-solution PAC checker settings merged with global `solutionCheck` settings (see below). Set `solutionCheck.enabled = $false` to skip checking a specific solution.
 
 ### Assets
 
@@ -192,6 +193,91 @@ If a deployment job times out, the solution import may still be running inside D
 4. Once the import has completed (successfully or not), it is safe to retry the pipeline stage.
 
 > **Future improvement:** Automating the detection of an in-progress import and waiting for it to complete is a planned enhancement.
+
+### Solution Check (PAC `solution check`)
+
+`BUILD` can run `pac solution check` against packed solution zip files and fail the build based on a configurable severity threshold.
+
+Configuration supports **global** defaults and **per-solution** overrides:
+
+- Global settings are defined in top-level `solutionCheck`.
+- Per-solution settings are defined in `solutions[].solutionCheck`.
+- They are merged, so you can set shared defaults globally and only override what differs per solution.
+- Arrays (`excludedFiles`, `ruleLevelOverride`) are merged by concatenation.
+- `ruleSet = 'none'` means `--ruleSet` is omitted.
+
+#### Global example
+
+```powershell
+solutionCheck = @{
+    enabled = $true
+    geo = 'Europe'
+    failThreshold = 'Critical'
+    ruleSet = 'Solution Checker'
+    excludedFiles = @(
+        'CanvasApps/**/*.msapp'
+    )
+    ruleLevelOverride = @(
+        @{ Id = 'meta-remove-dup-reg'; OverrideLevel = 'Medium' }
+    )
+    maxParallel = 4
+}
+```
+
+#### Per-solution override example
+
+```powershell
+solutions = @(
+    @{
+        name = 'ContosoCore'
+        solutionCheck = @{
+            enabled = $true
+            failThreshold = 'High'
+            ruleSet = 'none'
+        }
+    },
+    @{
+        name = 'LegacySolution'
+        solutionCheck = @{
+            enabled = $false
+        }
+    }
+)
+```
+
+#### Settings reference
+
+| Setting | Scope | Description |
+|---|---|---|
+| `enabled` | Global + Solution | Enables/disables checker. Build runs checks only for solutions where merged `enabled` is `$true`. |
+| `geo` | Global + Solution | PAC checker geography, e.g. `Europe`, `UnitedStates`, `Japan`. |
+| `failThreshold` | Global + Solution | Build fails when findings include this severity or higher. Values: `Critical`, `High`, `Medium`, `Low`, `Informational`. Default: `Critical`. |
+| `ruleSet` | Global + Solution | PAC rule set (for example `Solution Checker`, `AppSource Certification`, or GUID). Use `none` to omit `--ruleSet`. |
+| `excludedFiles` | Global + Solution | One or more glob patterns. Patterns are expanded to concrete file paths before calling PAC `--excludedFiles`. |
+| `ruleLevelOverride` | Global + Solution | Rule override definitions. Supported formats: JSON file path, hashtable, or array of rule override objects. |
+| `maxParallel` | Global | Maximum number of solutions checked in parallel. Default: `4`. |
+
+#### Authentication behavior for solution check
+
+ALM4Dataverse uses:
+
+```text
+pac auth create --managedIdentity
+```
+
+This uses Default Azure Credential and is designed to pick up an existing Azure identity context (for example Azure CLI sign-in, managed identity, or workload identity federation). If no non-interactive Azure identity context is available, solution check fails with a clear error.
+
+> `connect.ps1` also initializes PAC auth unconditionally so future PAC-based operations can reuse the same behavior.
+
+#### Reports and failure visibility
+
+When solution checks run, build output includes `solution-check/` artifacts:
+
+- `solution-check/summary.md`
+- `solution-check/solution-check-summary.json`
+- per-solution logs and PAC output folders
+
+Azure DevOps and GitHub build templates upload a dedicated `solution-check-report` artifact for easy viewing.
 
 ## Advanced - Fork Configuration
 

--- a/docs/setup/azdo-automated-setup.md
+++ b/docs/setup/azdo-automated-setup.md
@@ -84,4 +84,4 @@ The easiest way to run setup is:
      - **Workload Identity Federation**: Modern approach using federated credentials (no secrets required)
      - When ALM4Dataverse extension mode is disabled, only **Service Principal with Secret** is available.
 12) For both the dev environment and all deployment environments, prompts you to select the Service Account (user account) you want to use. This must be pre-existing as no option to create one is provided.
-13) Prompts whether solution validation should run during `BUILD` per configured branch. If enabled, setup ensures the branch has a DEV environment configuration and wires `BUILD` to use that environment for connect/auth steps (same model as `EXPORT`).
+13) Prompts whether solution validation should run during `BUILD` globally. If enabled, setup configures one shared BUILD validation environment (Dataverse URL + auth + service account) and wires all generated `BUILD` pipelines to use that environment for connect/auth steps (same model as `EXPORT`).

--- a/docs/setup/azdo-automated-setup.md
+++ b/docs/setup/azdo-automated-setup.md
@@ -84,3 +84,4 @@ The easiest way to run setup is:
      - **Workload Identity Federation**: Modern approach using federated credentials (no secrets required)
      - When ALM4Dataverse extension mode is disabled, only **Service Principal with Secret** is available.
 12) For both the dev environment and all deployment environments, prompts you to select the Service Account (user account) you want to use. This must be pre-existing as no option to create one is provided.
+13) Prompts whether solution validation should run during `BUILD` per configured branch. If enabled, setup ensures the branch has a DEV environment configuration and wires `BUILD` to use that environment for connect/auth steps (same model as `EXPORT`).

--- a/docs/setup/azdo-manual-setup.md
+++ b/docs/setup/azdo-manual-setup.md
@@ -406,13 +406,25 @@ Edit the `alm-config.psd1` file in your main repository to list the solutions yo
         @{
             name = 'AnotherSolution'
             deployUnmanaged = $false
+         solutionCheck = @{ enabled = $true; failThreshold = 'High' }
         }
     )
+
+   # Optional global PAC solution check settings used by BUILD.
+   solutionCheck = @{
+      enabled = $true
+      geo = 'Europe'
+      failThreshold = 'Critical'
+      maxParallel = 4
+   }
 }
 ```
 
 - `name`: The unique name of your Dataverse solution
 - `deployUnmanaged`: Set to `$true` if you want to deploy as unmanaged (typically only for Dev), `$false` for managed
+- `solutionCheck` (optional): Per-solution PAC checker settings merged with global `solutionCheck` settings
+
+If solution check is enabled, BUILD authenticates PAC using managed identity / existing Azure identity context and fails clearly if no non-interactive Azure sign-in context is available.
 
 ### 9.2 Configure Deployment Environments
 

--- a/docs/setup/github-setup.md
+++ b/docs/setup/github-setup.md
@@ -26,7 +26,7 @@ You call them from your own repository's workflow files, which you copy from the
 | `IMPORT.yml` | `import.yml` | Build from source, import into dev Dataverse |
 | `DEPLOY-main.yml` | `deploy.yml` | Deploy artifacts to each environment |
 
-During automated setup (`setup-github.ps1`), you are also prompted per branch whether to enable solution validation in `BUILD`. If enabled, setup associates the BUILD job with that branch's `Dev-<branch>` GitHub environment and wires reusable `build.yml` to run Dataverse connect/authentication before build validation.
+During automated setup (`setup-github.ps1`), you are also prompted whether to enable solution validation in `BUILD` globally. If enabled, setup configures one shared GitHub environment for BUILD validation and wires reusable `build.yml` to run Dataverse connect/authentication against that environment before build validation.
 
 ---
 

--- a/docs/setup/github-setup.md
+++ b/docs/setup/github-setup.md
@@ -143,11 +143,24 @@ Edit `alm-config.psd1` to list the solutions you want to manage:
 ```powershell
 @{
     solutions = @(
-        @{ name = 'YourSolutionUniqueName' }
-        @{ name = 'AnotherSolution' }
+    @{ name = 'YourSolutionUniqueName' }
+    @{
+      name = 'AnotherSolution'
+      solutionCheck = @{ enabled = $true; failThreshold = 'High' }
+    }
     )
+
+  # Optional global PAC solution check settings used by BUILD.
+  solutionCheck = @{
+    enabled = $true
+    geo = 'Europe'
+    failThreshold = 'Critical'
+    maxParallel = 4
+  }
 }
 ```
+
+If solution check is enabled, BUILD authenticates PAC using managed identity / existing Azure identity context and fails clearly if no non-interactive Azure sign-in context is available.
 
 ### Configure deployment environments in `DEPLOY-main.yml`
 

--- a/docs/setup/github-setup.md
+++ b/docs/setup/github-setup.md
@@ -26,6 +26,8 @@ You call them from your own repository's workflow files, which you copy from the
 | `IMPORT.yml` | `import.yml` | Build from source, import into dev Dataverse |
 | `DEPLOY-main.yml` | `deploy.yml` | Deploy artifacts to each environment |
 
+During automated setup (`setup-github.ps1`), you are also prompted per branch whether to enable solution validation in `BUILD`. If enabled, setup associates the BUILD job with that branch's `Dev-<branch>` GitHub environment and wires reusable `build.yml` to run Dataverse connect/authentication before build validation.
+
 ---
 
 ## Prerequisites

--- a/docs/usage/building-releases.md
+++ b/docs/usage/building-releases.md
@@ -31,6 +31,7 @@ To monitor:
 What happens:
 
 - Solution(s) are packed from the folders in source control at `solutions/uniquename` using PAC solution pack. A managed solution is generated and added to the build assets.
+- BUILD can optionally be associated with a Dataverse environment (typically `Dev-<branch>`). When configured, BUILD runs the same Dataverse connect/authentication flow as EXPORT before running build + solution validation.
 - If `solutionCheck.enabled = $true` (globally and/or per-solution), each packed solution is validated with `pac solution check`.
   - Multiple solutions are processed in parallel (`solutionCheck.maxParallel`, default `4`).
   - Build failure threshold is controlled by `solutionCheck.failThreshold` (default `Critical`).

--- a/docs/usage/building-releases.md
+++ b/docs/usage/building-releases.md
@@ -31,9 +31,22 @@ To monitor:
 What happens:
 
 - Solution(s) are packed from the folders in source control at `solutions/uniquename` using PAC solution pack. A managed solution is generated and added to the build assets.
+- If `solutionCheck.enabled = $true` (globally and/or per-solution), each packed solution is validated with `pac solution check`.
+  - Multiple solutions are processed in parallel (`solutionCheck.maxParallel`, default `4`).
+  - Build failure threshold is controlled by `solutionCheck.failThreshold` (default `Critical`).
 - If you've configured any hook extensions in `alm-config.psd1`, these will be executed and can add to the build steps and the assets.
 - Any additional paths configured in `assets` will be copied to the build assets.
 - The configuration and scripts for the deployment process are also copied to the build assets to ensure that everything is frozen in time.
+
+Solution check report outputs:
+
+- In build artifacts under `solution-check/`
+  - `summary.md`
+  - `solution-check-summary.json`
+  - per-solution PAC logs/output
+- As a dedicated CI artifact named `solution-check-report` for quick access from pipeline/workflow results.
+
+If checks fail, the logs clearly state which solution breached the configured threshold and what the highest severity was.
 
 What to do next:
 

--- a/docs/usage/building-releases.md
+++ b/docs/usage/building-releases.md
@@ -31,7 +31,7 @@ To monitor:
 What happens:
 
 - Solution(s) are packed from the folders in source control at `solutions/uniquename` using PAC solution pack. A managed solution is generated and added to the build assets.
-- BUILD can optionally be associated with a Dataverse environment (typically `Dev-<branch>`). When configured, BUILD runs the same Dataverse connect/authentication flow as EXPORT before running build + solution validation.
+- BUILD can optionally be associated with a global Dataverse validation environment. When configured, BUILD runs the same Dataverse connect/authentication flow as EXPORT before running build + solution validation.
 - If `solutionCheck.enabled = $true` (globally and/or per-solution), each packed solution is validated with `pac solution check`.
   - Multiple solutions are processed in parallel (`solutionCheck.maxParallel`, default `4`).
   - Build failure threshold is controlled by `solutionCheck.failThreshold` (default `Critical`).

--- a/pipelines/scripts/build.ps1
+++ b/pipelines/scripts/build.ps1
@@ -54,6 +54,488 @@ function Get-PacCliInstalledPackageVersion {
     return ''
 }
 
+function New-SolutionCheckSeverityCounts {
+    return [ordered]@{
+        Critical      = 0
+        High          = 0
+        Medium        = 0
+        Low           = 0
+        Informational = 0
+    }
+}
+
+function Convert-SolutionCheckSeverityToRank {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Severity
+    )
+
+    switch ($Severity.Trim().ToLowerInvariant()) {
+        'critical'      { return 5 }
+        'high'          { return 4 }
+        'medium'        { return 3 }
+        'low'           { return 2 }
+        'informational' { return 1 }
+        default         { throw "Unknown solution check severity '$Severity'. Supported values: Critical, High, Medium, Low, Informational." }
+    }
+}
+
+function Convert-SolutionCheckRankToSeverity {
+    param(
+        [Parameter(Mandatory = $true)]
+        [int]$Rank
+    )
+
+    switch ($Rank) {
+        5 { return 'Critical' }
+        4 { return 'High' }
+        3 { return 'Medium' }
+        2 { return 'Low' }
+        1 { return 'Informational' }
+        default { return 'None' }
+    }
+}
+
+function Get-SolutionCheckHighestSeverity {
+    param(
+        [Parameter(Mandatory = $true)]
+        [hashtable]$SeverityCounts
+    )
+
+    foreach ($severity in @('Critical', 'High', 'Medium', 'Low', 'Informational')) {
+        if ($SeverityCounts[$severity] -gt 0) {
+            return $severity
+        }
+    }
+
+    return 'None'
+}
+
+function Parse-SolutionCheckSeverityCounts {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ConsoleText
+    )
+
+    $counts = New-SolutionCheckSeverityCounts
+
+    foreach ($severity in @('Critical', 'High', 'Medium', 'Low', 'Informational')) {
+        $escaped = [regex]::Escape($severity)
+        $matches = [regex]::Matches($ConsoleText, "(?im)\b$escaped\b(?:\s+issues?)?\s*[:=]\s*(\d+)\b")
+        foreach ($match in $matches) {
+            $counts[$severity] += [int]$match.Groups[1].Value
+        }
+    }
+
+    return $counts
+}
+
+function Resolve-SolutionCheckExcludedFiles {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$SourceDirectory,
+
+        [Parameter(Mandatory = $true)]
+        [string]$SolutionName,
+
+        [Parameter(Mandatory = $true)]
+        [array]$Patterns
+    )
+
+    $solutionRoot = Join-Path $SourceDirectory "solutions/$SolutionName"
+    $resolvedFiles = New-Object System.Collections.Generic.List[string]
+
+    foreach ($pattern in $Patterns) {
+        if ($null -eq $pattern) {
+            continue
+        }
+
+        $patternText = [string]$pattern
+        if ([string]::IsNullOrWhiteSpace($patternText)) {
+            continue
+        }
+
+        $patternText = $patternText.Trim()
+        $searchPath = if ([System.IO.Path]::IsPathRooted($patternText)) {
+            $patternText
+        }
+        else {
+            Join-Path $solutionRoot $patternText
+        }
+
+        $matches = @(Get-ChildItem -Path $searchPath -File -Recurse -ErrorAction SilentlyContinue | Select-Object -ExpandProperty FullName)
+        if ($matches.Count -eq 0 -and (Test-Path $searchPath -PathType Leaf)) {
+            $matches = @((Resolve-Path $searchPath | Select-Object -ExpandProperty Path))
+        }
+
+        if ($matches.Count -eq 0) {
+            Write-Host "##[warning]No files matched excludedFiles pattern '$patternText' for solution '$SolutionName'."
+            continue
+        }
+
+        foreach ($match in $matches) {
+            if (-not $resolvedFiles.Contains($match)) {
+                $resolvedFiles.Add($match)
+            }
+        }
+    }
+
+    return @($resolvedFiles.ToArray())
+}
+
+function ConvertTo-SolutionCheckRuleOverrideFile {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ReportRoot,
+
+        [Parameter(Mandatory = $true)]
+        [string]$SolutionName,
+
+        $RuleLevelOverride
+    )
+
+    if ($null -eq $RuleLevelOverride) {
+        return ''
+    }
+
+    if ($RuleLevelOverride -is [string]) {
+        $candidate = [string]$RuleLevelOverride
+        if ([string]::IsNullOrWhiteSpace($candidate)) {
+            return ''
+        }
+
+        return $candidate
+    }
+
+    $safeSolutionName = $SolutionName -replace '[^a-zA-Z0-9._-]', '_'
+    $overridePath = Join-Path $ReportRoot "$safeSolutionName-ruleLevelOverride.json"
+
+    if ($RuleLevelOverride -is [hashtable]) {
+        @($RuleLevelOverride) | ConvertTo-Json -Depth 20 | Out-File -FilePath $overridePath -Encoding UTF8
+        return $overridePath
+    }
+
+    if ($RuleLevelOverride -is [array]) {
+        @($RuleLevelOverride) | ConvertTo-Json -Depth 20 | Out-File -FilePath $overridePath -Encoding UTF8
+        return $overridePath
+    }
+
+    throw "solutionCheck.ruleLevelOverride for solution '$SolutionName' must be a JSON file path string, hashtable, or array."
+}
+
+function Write-SolutionCheckSummary {
+    param(
+        [Parameter(Mandatory = $true)]
+        [array]$Results,
+
+        [Parameter(Mandatory = $true)]
+        [string]$SummaryPath,
+
+        [Parameter(Mandatory = $true)]
+        [string]$SummaryJsonPath
+    )
+
+    $lines = New-Object System.Collections.Generic.List[string]
+    $lines.Add('# Solution Check Summary')
+    $lines.Add('')
+    $lines.Add('| Solution | Status | Threshold | Highest | Critical | High | Medium | Low | Informational |')
+    $lines.Add('|---|---:|---:|---:|---:|---:|---:|---:|---:|')
+
+    foreach ($result in $Results) {
+        $status = if ($result.Error) {
+            'Error'
+        }
+        elseif ($result.ThresholdBreached) {
+            'Failed'
+        }
+        else {
+            'Passed'
+        }
+
+        $lines.Add("| $($result.SolutionName) | $status | $($result.FailThreshold) | $($result.HighestSeverity) | $($result.SeverityCounts.Critical) | $($result.SeverityCounts.High) | $($result.SeverityCounts.Medium) | $($result.SeverityCounts.Low) | $($result.SeverityCounts.Informational) |")
+    }
+
+    $lines.Add('')
+    $summaryText = $lines -join "`r`n"
+    $summaryText | Out-File -FilePath $SummaryPath -Encoding UTF8
+
+    $jsonSummary = @{
+        generatedAtUtc = (Get-Date).ToUniversalTime().ToString('o')
+        results = $Results
+    }
+    $jsonSummary | ConvertTo-Json -Depth 30 | Out-File -FilePath $SummaryJsonPath -Encoding UTF8
+
+    if (-not [string]::IsNullOrWhiteSpace($env:GITHUB_STEP_SUMMARY)) {
+        $summaryText | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($env:TF_BUILD)) {
+        Write-Host "##vso[task.addattachment type=Distributedtask.Core.Summary;name=Solution Check Summary;]$SummaryPath"
+    }
+}
+
+function Invoke-SolutionCheck {
+    param(
+        [Parameter(Mandatory = $true)]
+        [hashtable]$Config,
+
+        [Parameter(Mandatory = $true)]
+        [string]$SourceDirectory,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ArtifactStagingDirectory
+    )
+
+    $globalSolutionCheck = @{}
+    if ($Config.solutionCheck -is [hashtable]) {
+        $globalSolutionCheck = $Config.solutionCheck
+    }
+
+    $solutionCheckEnabled = $false
+    foreach ($solution in $Config.solutions) {
+        $solutionLevel = if ($solution.solutionCheck -is [hashtable]) { $solution.solutionCheck } else { @{} }
+        $merged = Merge-AlmConfigValue -DefaultValue $globalSolutionCheck -OverrideValue $solutionLevel
+        if ($merged -is [hashtable] -and $merged.ContainsKey('enabled') -and [bool]$merged.enabled) {
+            $solutionCheckEnabled = $true
+            break
+        }
+    }
+
+    if (-not $solutionCheckEnabled) {
+        Write-Host "##[section]Solution check skipped (solutionCheck.enabled is false for all solutions)."
+        return
+    }
+
+    $solutionCheckRoot = Join-Path $ArtifactStagingDirectory 'solution-check'
+    if (-not (Test-Path $solutionCheckRoot)) {
+        New-Item -ItemType Directory -Path $solutionCheckRoot -Force | Out-Null
+    }
+
+    Initialize-PacAuthentication -Quiet
+
+    $maxParallel = 4
+    if ($globalSolutionCheck.ContainsKey('maxParallel') -and $null -ne $globalSolutionCheck.maxParallel) {
+        $maxParallel = [int]$globalSolutionCheck.maxParallel
+    }
+    if ($maxParallel -lt 1) {
+        $maxParallel = 1
+    }
+
+    $plans = New-Object System.Collections.Generic.List[object]
+    foreach ($solution in $Config.solutions) {
+        $solutionName = [string]$solution.name
+        $solutionLevel = if ($solution.solutionCheck -is [hashtable]) { $solution.solutionCheck } else { @{} }
+        $settings = Merge-AlmConfigValue -DefaultValue $globalSolutionCheck -OverrideValue $solutionLevel
+        if (-not ($settings -is [hashtable])) {
+            continue
+        }
+
+        $enabled = $settings.ContainsKey('enabled') -and [bool]$settings.enabled
+        if (-not $enabled) {
+            continue
+        }
+
+        $geo = if ($settings.ContainsKey('geo') -and -not [string]::IsNullOrWhiteSpace([string]$settings.geo)) {
+            [string]$settings.geo
+        }
+        else {
+            'Europe'
+        }
+
+        $ruleSetRaw = if ($settings.ContainsKey('ruleSet')) { [string]$settings.ruleSet } else { '' }
+        $ruleSetValue = if ([string]::IsNullOrWhiteSpace($ruleSetRaw) -or $ruleSetRaw.Trim().ToLowerInvariant() -eq 'none') {
+            ''
+        }
+        else {
+            $ruleSetRaw.Trim()
+        }
+
+        $failThreshold = if ($settings.ContainsKey('failThreshold') -and -not [string]::IsNullOrWhiteSpace([string]$settings.failThreshold)) {
+            [string]$settings.failThreshold
+        }
+        else {
+            'Critical'
+        }
+
+        $excludedFilesRaw = @()
+        if ($settings.ContainsKey('excludedFiles') -and $null -ne $settings.excludedFiles) {
+            if ($settings.excludedFiles -is [string]) {
+                $excludedFilesRaw = @([string]$settings.excludedFiles)
+            }
+            elseif ($settings.excludedFiles -is [array]) {
+                $excludedFilesRaw = @($settings.excludedFiles)
+            }
+            else {
+                throw "solutionCheck.excludedFiles for solution '$solutionName' must be a string or array of strings."
+            }
+        }
+
+        $resolvedExcludedFiles = Resolve-SolutionCheckExcludedFiles -SourceDirectory $SourceDirectory -SolutionName $solutionName -Patterns $excludedFilesRaw
+        $ruleOverrideFile = ConvertTo-SolutionCheckRuleOverrideFile -ReportRoot $solutionCheckRoot -SolutionName $solutionName -RuleLevelOverride $settings.ruleLevelOverride
+
+        $plans.Add([pscustomobject]@{
+            SolutionName   = $solutionName
+            SolutionZip    = Join-Path $ArtifactStagingDirectory "solutions/$solutionName.zip"
+            Geo            = $geo
+            RuleSet        = $ruleSetValue
+            ExcludedFiles  = @($resolvedExcludedFiles)
+            RuleLevelFile  = $ruleOverrideFile
+            FailThreshold  = $failThreshold
+            ReportRoot     = $solutionCheckRoot
+        })
+    }
+
+    if ($plans.Count -eq 0) {
+        Write-Host "##[section]Solution check skipped (no enabled solutions)."
+        return
+    }
+
+    Write-Host "##[section]Running PAC solution checks for $($plans.Count) solution(s) with max parallelism $maxParallel"
+
+    $results = @($plans | ForEach-Object -ThrottleLimit $maxParallel -Parallel {
+        $plan = $_
+        $ErrorActionPreference = 'Stop'
+
+        function New-Counts {
+            return [ordered]@{ Critical = 0; High = 0; Medium = 0; Low = 0; Informational = 0 }
+        }
+
+        function Parse-Counts {
+            param([string]$Text)
+
+            $counts = New-Counts
+            foreach ($severity in @('Critical', 'High', 'Medium', 'Low', 'Informational')) {
+                $escaped = [regex]::Escape($severity)
+                $matches = [regex]::Matches($Text, "(?im)\b$escaped\b(?:\s+issues?)?\s*[:=]\s*(\d+)\b")
+                foreach ($match in $matches) {
+                    $counts[$severity] += [int]$match.Groups[1].Value
+                }
+            }
+            return $counts
+        }
+
+        function Get-Highest {
+            param([hashtable]$Counts)
+            foreach ($severity in @('Critical', 'High', 'Medium', 'Low', 'Informational')) {
+                if ($Counts[$severity] -gt 0) { return $severity }
+            }
+            return 'None'
+        }
+
+        $safeName = $plan.SolutionName -replace '[^a-zA-Z0-9._-]', '_'
+        $reportDirectory = Join-Path $plan.ReportRoot $safeName
+        if (-not (Test-Path $reportDirectory)) {
+            New-Item -ItemType Directory -Path $reportDirectory -Force | Out-Null
+        }
+
+        try {
+            if (-not (Test-Path $plan.SolutionZip)) {
+                throw "Packed solution zip not found: $($plan.SolutionZip)"
+            }
+
+            $pac = Get-Command pac -ErrorAction SilentlyContinue
+            if (-not $pac) {
+                throw 'Power Apps CLI (pac) was not found on PATH.'
+            }
+
+            $args = @('solution', 'check', '--path', $plan.SolutionZip, '--outputDirectory', $reportDirectory, '--geo', $plan.Geo)
+
+            if (-not [string]::IsNullOrWhiteSpace($plan.RuleSet)) {
+                $args += @('--ruleSet', $plan.RuleSet)
+            }
+
+            if ($plan.ExcludedFiles -and $plan.ExcludedFiles.Count -gt 0) {
+                $args += @('--excludedFiles', ($plan.ExcludedFiles -join ','))
+            }
+
+            if (-not [string]::IsNullOrWhiteSpace($plan.RuleLevelFile)) {
+                $args += @('--ruleLevelOverride', $plan.RuleLevelFile)
+            }
+
+            $output = @(& $pac.Source @args 2>&1)
+            $exitCode = $LASTEXITCODE
+            $outputText = ($output | ForEach-Object { [string]$_ }) -join "`r`n"
+            $outputText | Out-File -FilePath (Join-Path $reportDirectory 'pac-solution-check.log') -Encoding UTF8
+
+            $counts = Parse-Counts -Text $outputText
+            $highest = Get-Highest -Counts $counts
+
+            return [pscustomobject]@{
+                SolutionName      = $plan.SolutionName
+                ExitCode          = $exitCode
+                Error             = $exitCode -ne 0
+                ErrorMessage      = if ($exitCode -ne 0) { "PAC exited with code $exitCode" } else { '' }
+                ReportDirectory   = $reportDirectory
+                SeverityCounts    = $counts
+                HighestSeverity   = $highest
+                FailThreshold     = $plan.FailThreshold
+                ThresholdBreached = $false
+            }
+        }
+        catch {
+            $message = $_.Exception.Message
+            $message | Out-File -FilePath (Join-Path $reportDirectory 'pac-solution-check.error.log') -Encoding UTF8
+
+            return [pscustomobject]@{
+                SolutionName      = $plan.SolutionName
+                ExitCode          = -1
+                Error             = $true
+                ErrorMessage      = $message
+                ReportDirectory   = $reportDirectory
+                SeverityCounts    = (New-Counts)
+                HighestSeverity   = 'None'
+                FailThreshold     = $plan.FailThreshold
+                ThresholdBreached = $false
+            }
+        }
+    })
+
+    $hasFailures = $false
+    foreach ($result in $results) {
+        if ($result.Error) {
+            $hasFailures = $true
+            continue
+        }
+
+        $highestRank = if ($result.HighestSeverity -eq 'None') { 0 } else { Convert-SolutionCheckSeverityToRank -Severity $result.HighestSeverity }
+        $thresholdRank = Convert-SolutionCheckSeverityToRank -Severity $result.FailThreshold
+
+        if ($highestRank -ge $thresholdRank -and $highestRank -gt 0) {
+            $result.ThresholdBreached = $true
+            $hasFailures = $true
+        }
+    }
+
+    $summaryMarkdownPath = Join-Path $solutionCheckRoot 'summary.md'
+    $summaryJsonPath = Join-Path $solutionCheckRoot 'solution-check-summary.json'
+    Write-SolutionCheckSummary -Results $results -SummaryPath $summaryMarkdownPath -SummaryJsonPath $summaryJsonPath
+
+    foreach ($result in $results) {
+        if ($result.Error) {
+            Write-Host "##[error]Solution check failed for '$($result.SolutionName)': $($result.ErrorMessage)"
+            if (-not [string]::IsNullOrWhiteSpace($env:TF_BUILD)) {
+                Write-Host "##vso[task.logissue type=error]Solution check failed for '$($result.SolutionName)': $($result.ErrorMessage)"
+            }
+            continue
+        }
+
+        if ($result.ThresholdBreached) {
+            $message = "Solution '$($result.SolutionName)' exceeded threshold '$($result.FailThreshold)' with highest severity '$($result.HighestSeverity)'."
+            Write-Host "##[error]$message"
+            if (-not [string]::IsNullOrWhiteSpace($env:TF_BUILD)) {
+                Write-Host "##vso[task.logissue type=error]$message"
+            }
+        }
+        else {
+            Write-Host "##[section]Solution '$($result.SolutionName)' passed solution check (highest severity: $($result.HighestSeverity), threshold: $($result.FailThreshold))."
+        }
+    }
+
+    if ($hasFailures) {
+        throw "One or more solution checks failed. See '$summaryMarkdownPath' and the per-solution logs under '$solutionCheckRoot'."
+    }
+}
+
 # Read solutions configuration
 $config = Get-AlmConfig -BaseDirectory $SourceDirectory
 Write-Host "##[debug]Loaded configuration from alm-config.psd1"
@@ -77,6 +559,8 @@ foreach ($solution in $config.solutions) {
     
     Write-Host "##[endgroup]"
 }
+
+Invoke-SolutionCheck -Config $config -SourceDirectory $SourceDirectory -ArtifactStagingDirectory $ArtifactStagingDirectory
 
 if ($config.assets -and $config.assets.Count -gt 0) {
     Write-Host "##[group]Copying extra asset files"

--- a/pipelines/scripts/build.ps1
+++ b/pipelines/scripts/build.ps1
@@ -311,8 +311,6 @@ function Invoke-SolutionCheck {
         New-Item -ItemType Directory -Path $solutionCheckRoot -Force | Out-Null
     }
 
-    Initialize-PacAuthentication -Quiet
-
     $maxParallel = 4
     if ($globalSolutionCheck.ContainsKey('maxParallel') -and $null -ne $globalSolutionCheck.maxParallel) {
         $maxParallel = [int]$globalSolutionCheck.maxParallel

--- a/pipelines/scripts/build.ps1
+++ b/pipelines/scripts/build.ps1
@@ -370,7 +370,10 @@ function Invoke-SolutionCheck {
             }
         }
 
-        $resolvedExcludedFiles = Resolve-SolutionCheckExcludedFiles -SourceDirectory $SourceDirectory -SolutionName $solutionName -Patterns $excludedFilesRaw
+        $resolvedExcludedFiles = @()
+        if (@($excludedFilesRaw).Count -gt 0) {
+            $resolvedExcludedFiles = Resolve-SolutionCheckExcludedFiles -SourceDirectory $SourceDirectory -SolutionName $solutionName -Patterns $excludedFilesRaw
+        }
         $ruleOverrideFile = ConvertTo-SolutionCheckRuleOverrideFile -ReportRoot $solutionCheckRoot -SolutionName $solutionName -RuleLevelOverride $settings.ruleLevelOverride
 
         $plans.Add([pscustomobject]@{

--- a/pipelines/scripts/common.ps1
+++ b/pipelines/scripts/common.ps1
@@ -6,6 +6,36 @@
     such as build.ps1, deploy.ps1, and export.ps1.
 #>
 
+function Merge-AlmConfigValue {
+    param(
+        $DefaultValue,
+        $OverrideValue
+    )
+
+    if ($null -eq $DefaultValue) {
+        return $OverrideValue
+    }
+
+    if ($null -eq $OverrideValue) {
+        return $DefaultValue
+    }
+
+    if ($DefaultValue -is [array] -and $OverrideValue -is [array]) {
+        return @(@($DefaultValue) + @($OverrideValue))
+    }
+
+    if ($DefaultValue -is [hashtable] -and $OverrideValue -is [hashtable]) {
+        $merged = @{}
+        foreach ($key in ($DefaultValue.Keys + $OverrideValue.Keys | Select-Object -Unique)) {
+            $merged[$key] = Merge-AlmConfigValue -DefaultValue $DefaultValue[$key] -OverrideValue $OverrideValue[$key]
+        }
+
+        return $merged
+    }
+
+    return $OverrideValue
+}
+
 function Get-AlmConfig {
     param(
         [string]$BaseDirectory = "."
@@ -28,50 +58,10 @@ function Get-AlmConfig {
 
     $mainConfig = Import-PowerShellDataFile -Path $configPath
 
-    function mergeConfigValue($defaultConfig, $mainConfig) {
-        if (-not $defaultConfig) {
-            return $mainConfig
-        }
-
-        if (-not $mainConfig) {
-            return $defaultConfig
-        }
-
-        # If both are arrays, concatenate them
-        if ($defaultConfig -is [array] -and $mainConfig -is [array]) {
-            return @(@($defaultConfig) + @($mainConfig))
-        }
-
-        # If neither is a hashtable, main value wins (primitive override)
-        if ($defaultConfig -isnot [hashtable] -or $mainConfig -isnot [hashtable]) {
-            return $mainConfig
-        }
-
-        $newValue = @{}
-        foreach ($subKey in $defaultConfig.Keys + $mainConfig.Keys | Select-Object -Unique) {
-            $newValue[$subKey] = mergeConfigValue $defaultConfig[$subKey] $mainConfig[$subKey]
-        }
-        return $newValue
-    }
-    
     # Merge configs: mainConfig overrides defaultConfig, arrays are concatenated
     foreach ($key in $mainConfig.Keys) {
         if ($defaultConfig.ContainsKey($key)) {
-            $defaultValue = $defaultConfig[$key]
-            $mainValue = $mainConfig[$key]
-            
-            # If both are arrays, concatenate them
-            if ($defaultValue -is [array] -and $mainValue -is [array]) {
-                $config[$key] = @(@($defaultValue) + @($mainValue)) 
-            }
-            # If both are hashtables, merge them
-            elseif ($defaultValue -is [hashtable] -and $mainValue -is [hashtable]) {
-                $config[$key] = mergeConfigValue $defaultValue $mainValue
-            }
-            # Otherwise, main value wins
-            else {
-                $config[$key] = $mainValue
-            }
+            $config[$key] = Merge-AlmConfigValue -DefaultValue $defaultConfig[$key] -OverrideValue $mainConfig[$key]
         }
         else {
             $config[$key] = $mainConfig[$key]
@@ -92,6 +82,58 @@ function Get-AlmConfig {
     
     return $config
 }
+
+    function Initialize-PacAuthentication {
+        param(
+            [string]$ProfileName = 'ALM4Dataverse-SolutionCheck',
+            [switch]$Quiet
+        )
+
+        $pacCommand = Get-Command pac -ErrorAction SilentlyContinue
+        if (-not $pacCommand) {
+            throw "Power Apps CLI (pac) is not available on PATH. Ensure installdependencies.ps1 has run in this job before calling scripts that require PAC authentication."
+        }
+
+        $pacPath = $pacCommand.Source
+
+        Write-Host "##[group]Authenticating Power Apps CLI using managed identity / Azure identity context"
+
+        $createArgs = @('auth', 'create', '--managedIdentity', '--name', $ProfileName)
+        $createOutput = @(& $pacPath @createArgs 2>&1)
+        $createExitCode = $LASTEXITCODE
+
+        if ($createExitCode -ne 0) {
+            $selectOutput = @(& $pacPath auth select --name $ProfileName 2>&1)
+            $selectExitCode = $LASTEXITCODE
+
+            if ($selectExitCode -ne 0) {
+                $createText = ($createOutput | ForEach-Object { [string]$_ }) -join "`n"
+                $selectText = ($selectOutput | ForEach-Object { [string]$_ }) -join "`n"
+                throw @(
+                    "Failed to establish PAC authentication using the existing Azure identity context.",
+                    "Expected an existing non-interactive Azure sign-in context (for example Azure CLI, managed identity, or workload identity).",
+                    "pac auth create output:",
+                    $createText,
+                    "pac auth select output:",
+                    $selectText
+                ) -join "`n"
+            }
+        }
+
+        $whoOutput = @(& $pacPath auth who 2>&1)
+        if ($LASTEXITCODE -ne 0) {
+            $whoText = ($whoOutput | ForEach-Object { [string]$_ }) -join "`n"
+            throw "PAC authentication validation failed (pac auth who).`n$whoText"
+        }
+
+        if (-not $Quiet) {
+            foreach ($line in $whoOutput) {
+                Write-Host $line
+            }
+        }
+
+        Write-Host "##[endgroup]"
+    }
 
 function Invoke-Hooks {
     param(

--- a/pipelines/scripts/connect.ps1
+++ b/pipelines/scripts/connect.ps1
@@ -16,6 +16,10 @@ param(
     [string]$url
 )
 
+. (Join-Path $PSScriptRoot 'common.ps1')
+
+Initialize-PacAuthentication
+
 Write-Host "##[group] Connecting to Dataverse environment with URL: $url"
 Get-DataverseConnection -setasdefault -DefaultAzureCredential -Url $url | out-null
 Write-Host "Validating connection using WhoAmI..."

--- a/pipelines/templates/build.yml
+++ b/pipelines/templates/build.yml
@@ -38,9 +38,28 @@ stages:
 
         - task: PublishPipelineArtifact@1
           displayName: 'Publish Artifacts'
+          condition: succeededOrFailed()
           inputs:
             targetPath: '$(Build.ArtifactStagingDirectory)'
             artifact: 'artifacts'
+
+        - pwsh: |
+            if (Test-Path "$(Build.ArtifactStagingDirectory)/solution-check") {
+              Write-Host "##vso[task.setvariable variable=HasSolutionCheckReport]true"
+              Write-Host "Solution check report folder detected."
+            } else {
+              Write-Host "##vso[task.setvariable variable=HasSolutionCheckReport]false"
+              Write-Host "No solution check report folder found."
+            }
+          displayName: 'Detect Solution Check Report'
+          condition: succeededOrFailed()
+
+        - task: PublishPipelineArtifact@1
+          displayName: 'Publish Solution Check Report'
+          condition: and(succeededOrFailed(), eq(variables['HasSolutionCheckReport'], 'true'))
+          inputs:
+            targetPath: '$(Build.ArtifactStagingDirectory)/solution-check'
+            artifact: 'solution-check-report'
 
         - pwsh: |
             $ErrorActionPreference = 'Stop'

--- a/pipelines/templates/build.yml
+++ b/pipelines/templates/build.yml
@@ -1,3 +1,11 @@
+parameters:
+- name: useAlm4DataverseExtension
+  type: boolean
+  default: true
+- name: buildEnvironmentName
+  type: string
+  default: ''
+
 stages:
   - stage: Build
     displayName: 'Build'
@@ -28,13 +36,96 @@ stages:
           inputs:
             AddToolsToPath: false
 
-        - pwsh: |
-            & "$(Pipeline.Workspace)/alm/pipelines/scripts/installdependencies.ps1"
-            & "$(Pipeline.Workspace)/alm/pipelines/scripts/build.ps1" `
-              -SourceDirectory "$(Pipeline.Workspace)/self" `
-              -ArtifactStagingDirectory "$(Build.ArtifactStagingDirectory)"
-          displayName: 'Install Dependencies and Build artifacts'
-          workingDirectory: '$(Pipeline.Workspace)/self'
+        - ${{ if ne(parameters.buildEnvironmentName, '') }}:
+          - ${{ if eq(parameters.useAlm4DataverseExtension, true) }}:
+            - task: ALM4Dataverse.alm4dataverse-azdo-extensions.alm4dataverse-set-connection-variables.ALM4DataverseSetConnectionVariables@1
+              displayName: 'Set Connection Variables'
+              name: ALM4DataverseSetConnectionVariables
+              inputs:
+                authenticationType: 'PowerPlatformSPN'
+                PowerPlatformSPN: ${{ parameters.buildEnvironmentName }}
+
+          - ${{ if ne(parameters.useAlm4DataverseExtension, true) }}:
+            - task: microsoft-IsvExpTools.PowerPlatform-BuildTools.set-connection-variables.PowerPlatformSetConnectionVariables@2
+              displayName: 'Set Connection Variables'
+              name: PowerPlatformSetConnectionVariables
+              inputs:
+                authenticationType: 'PowerPlatformSPN'
+                PowerPlatformSPN: ${{ parameters.buildEnvironmentName }}
+
+          - pwsh: |
+              & "$(Pipeline.Workspace)/alm/pipelines/scripts/installdependencies.ps1"
+
+              $environmentUrl = '$(ALM4DataverseSetConnectionVariables.EnvironmentUrl)'
+              if ([string]::IsNullOrWhiteSpace($environmentUrl) -or $environmentUrl -match '^\$\(.+\)$') {
+                $environmentUrl = '$(BuildTools.EnvironmentUrl)'
+              }
+              if ([string]::IsNullOrWhiteSpace($environmentUrl) -or $environmentUrl -match '^\$\(.+\)$') {
+                throw "Environment URL could not be resolved from the selected connection variables task. Ensure the Power Platform service connection is configured correctly."
+              }
+
+              $useAlm4DataverseExtension = '${{ parameters.useAlm4DataverseExtension }}' -eq 'true'
+              if (-not $useAlm4DataverseExtension) {
+                function Resolve-ConnectionVariable {
+                  param([string[]]$Candidates)
+
+                  foreach ($candidate in $Candidates) {
+                    if (-not [string]::IsNullOrWhiteSpace($candidate) -and $candidate -notmatch '^\$\(.+\)$') {
+                      return $candidate
+                    }
+                  }
+
+                  return $null
+                }
+
+                $resolvedClientId = Resolve-ConnectionVariable @(
+                  $env:AZURE_CLIENT_ID
+                  '$(PowerPlatformSetConnectionVariables.BuildTools.ApplicationId)'
+                  '$(BuildTools.ApplicationId)'
+                )
+                $resolvedTenantId = Resolve-ConnectionVariable @(
+                  $env:AZURE_TENANT_ID
+                  '$(PowerPlatformSetConnectionVariables.BuildTools.TenantId)'
+                  '$(BuildTools.TenantId)'
+                )
+                $resolvedClientSecret = Resolve-ConnectionVariable @(
+                  $env:AZURE_CLIENT_SECRET
+                  '$(PowerPlatformSetConnectionVariables.BuildTools.ClientSecret)'
+                  '$(BuildTools.ClientSecret)'
+                )
+
+                if ([string]::IsNullOrWhiteSpace($resolvedClientId) -or [string]::IsNullOrWhiteSpace($resolvedTenantId) -or [string]::IsNullOrWhiteSpace($resolvedClientSecret)) {
+                  throw "Service principal credentials could not be resolved from Set Connection Variables task outputs. Verify the Power Platform service connection and task output variable names."
+                }
+
+                $env:AZURE_CLIENT_ID = $resolvedClientId
+                $env:AZURE_TENANT_ID = $resolvedTenantId
+                $env:AZURE_CLIENT_SECRET = $resolvedClientSecret
+              }
+
+              & "$(Pipeline.Workspace)/alm/pipelines/scripts/connect.ps1" -Url $environmentUrl
+
+              & "$(Pipeline.Workspace)/alm/pipelines/scripts/build.ps1" `
+                -SourceDirectory "$(Pipeline.Workspace)/self" `
+                -ArtifactStagingDirectory "$(Build.ArtifactStagingDirectory)"
+            displayName: 'Install Dependencies, Connect and Build artifacts'
+            workingDirectory: '$(Pipeline.Workspace)/self'
+            env:
+              ${{ if eq(parameters.useAlm4DataverseExtension, true) }}:
+                AZURE_CLIENT_SECRET: $(AZURE_CLIENT_SECRET)
+              ${{ if ne(parameters.useAlm4DataverseExtension, true) }}:
+                AZURE_CLIENT_ID: $(PowerPlatformSetConnectionVariables.BuildTools.ApplicationId)
+                AZURE_TENANT_ID: $(PowerPlatformSetConnectionVariables.BuildTools.TenantId)
+                AZURE_CLIENT_SECRET: $(PowerPlatformSetConnectionVariables.BuildTools.ClientSecret)
+
+        - ${{ if eq(parameters.buildEnvironmentName, '') }}:
+          - pwsh: |
+              & "$(Pipeline.Workspace)/alm/pipelines/scripts/installdependencies.ps1"
+              & "$(Pipeline.Workspace)/alm/pipelines/scripts/build.ps1" `
+                -SourceDirectory "$(Pipeline.Workspace)/self" `
+                -ArtifactStagingDirectory "$(Build.ArtifactStagingDirectory)"
+            displayName: 'Install Dependencies and Build artifacts'
+            workingDirectory: '$(Pipeline.Workspace)/self'
 
         - task: PublishPipelineArtifact@1
           displayName: 'Publish Artifacts'

--- a/setup-azdo.ps1
+++ b/setup-azdo.ps1
@@ -3255,12 +3255,15 @@ function Update-AlmConfigInWorkingTree {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)][array]$Solutions,
+        [Parameter(Mandatory)][bool]$BuildValidationEnabled,
         [Parameter(Mandatory)][string]$RepoRoot
     )
 
     $configPath = Join-Path $RepoRoot 'alm-config.psd1'
     $templatePath = if ($PSScriptRoot) { Join-Path $PSScriptRoot 'copy-to-your-repo\alm-config.psd1' } else { $null }
-    $changed = Set-AlmConfigSolutionsInFile -ConfigPath $configPath -Solutions $Solutions -CreateIfMissing -TemplatePath $templatePath
+    $solutionsChanged = Set-AlmConfigSolutionsInFile -ConfigPath $configPath -Solutions $Solutions -CreateIfMissing -TemplatePath $templatePath
+    $solutionCheckChanged = Set-AlmConfigSolutionCheckEnabledInFile -ConfigPath $configPath -Enabled $BuildValidationEnabled -CreateIfMissing -TemplatePath $templatePath
+    $changed = ($solutionsChanged -or $solutionCheckChanged)
 
     if ($changed) {
         Write-Host 'Updated alm-config.psd1 in the working tree.' -ForegroundColor Green
@@ -3270,6 +3273,45 @@ function Update-AlmConfigInWorkingTree {
     }
 
     return $changed
+}
+
+function Update-AzDoBuildPipelineInWorkingTree {
+        [CmdletBinding()]
+        param(
+                [Parameter(Mandatory)][string]$RepoRoot,
+        [Parameter(Mandatory)][string]$SharedRepositoryName,
+                [Parameter(Mandatory)][string]$BuildEnvironmentName,
+                [Parameter(Mandatory)][bool]$UseAlm4DataverseExtension
+        )
+
+        $buildPipelinePath = Join-Path $RepoRoot 'pipelines/BUILD.yml'
+        if (-not (Test-Path -LiteralPath $buildPipelinePath)) {
+                throw "Build pipeline file not found: $buildPipelinePath"
+        }
+
+        $extensionLiteral = if ($UseAlm4DataverseExtension) { 'true' } else { 'false' }
+        $escapedBuildEnvironmentName = ([string]$BuildEnvironmentName).Replace("'", "''")
+
+        $newContent = @"
+trigger:
+    branches:
+        include:
+        - '*'  # Support any branch name
+
+resources:
+    repositories:
+        - repository: ALM4Dataverse
+            type: git
+            name: $SharedRepositoryName
+
+stages:
+- template: pipelines/templates/build.yml@ALM4Dataverse
+    parameters:
+        useAlm4DataverseExtension: $extensionLiteral
+        buildEnvironmentName: '$escapedBuildEnvironmentName'
+"@
+
+        Set-Content -LiteralPath $buildPipelinePath -Value $newContent.TrimStart("`r", "`n") -NoNewline
 }
 
 #endregion
@@ -3795,6 +3837,7 @@ function New-AzDoBranchSetupState {
         [Parameter(Mandatory)][string]$BranchName,
         [Parameter()][object]$ExistingDevEnvironment,
         [Parameter()][array]$DeploymentEnvironments,
+        [Parameter()][bool]$BuildValidationEnabled = $false,
         [Parameter()][object]$PublishPlan
     )
 
@@ -3805,6 +3848,7 @@ function New-AzDoBranchSetupState {
         ExistingDevEnvironment      = $ExistingDevEnvironment
         DevEnvironmentConfiguration = $null
         DeploymentEnvironments      = $normalizedDeploymentEnvironments
+        BuildValidationEnabled      = $BuildValidationEnabled
         PublishPlan                 = $PublishPlan
     }
 }
@@ -4269,7 +4313,8 @@ function Publish-AzDoBranchSetupChanges {
         [Parameter(Mandatory)][string]$SharedRepositoryName,
         [Parameter(Mandatory)][bool]$UseAlm4DataverseExtension,
         [Parameter()][array]$Solutions,
-        [Parameter()][array]$DeploymentEnvironments
+        [Parameter()][array]$DeploymentEnvironments,
+        [Parameter()][bool]$BuildValidationEnabled = $false
     )
 
     Push-Location $RepoRoot
@@ -4370,9 +4415,15 @@ function Publish-AzDoBranchSetupChanges {
             -Branch $ConfiguredBranch `
             -UseAlm4DataverseExtension $UseAlm4DataverseExtension
 
-        if ($null -ne $Solutions) {
-            [void](Update-AlmConfigInWorkingTree -Solutions @($Solutions) -RepoRoot $RepoRoot)
-        }
+        $effectiveSolutions = if ($null -ne $Solutions) { @($Solutions) } else { @() }
+        [void](Update-AlmConfigInWorkingTree -Solutions $effectiveSolutions -BuildValidationEnabled $BuildValidationEnabled -RepoRoot $RepoRoot)
+
+        $buildEnvironmentName = if ($BuildValidationEnabled) { "Dev-$ConfiguredBranch" } else { '' }
+        Update-AzDoBuildPipelineInWorkingTree `
+            -RepoRoot $RepoRoot `
+            -SharedRepositoryName $SharedRepositoryName `
+            -BuildEnvironmentName $buildEnvironmentName `
+            -UseAlm4DataverseExtension $UseAlm4DataverseExtension
 
         [void](Update-DeployPipelineInWorkingTree -Environments @($DeploymentEnvironments) -RepoRoot $RepoRoot -Branch $ConfiguredBranch -UseAlm4DataverseExtension $UseAlm4DataverseExtension)
 
@@ -4579,6 +4630,7 @@ function Invoke-AzDoBranchAwareSetup {
                         DevEnvironmentConfiguration = $_.DevEnvironmentConfiguration
                         ExistingDevEnvironment      = $_.ExistingDevEnvironment
                         Environments                = @($_.DeploymentEnvironments)
+                        BuildValidationEnabled      = [bool]$_.BuildValidationEnabled
                     }
                 })
 
@@ -4702,6 +4754,9 @@ function Invoke-AzDoBranchAwareSetup {
                         $existingBranchState = $existingStateByBranch[$branchKey]
                         $existingBranchState.DevEnvironmentConfiguration = $selectedBranchMapping.DevEnvironmentConfiguration
                         $existingBranchState.DeploymentEnvironments = @($selectedBranchMapping.Environments)
+                        if ($selectedBranchMapping.PSObject.Properties.Name -contains 'BuildValidationEnabled') {
+                            $existingBranchState.BuildValidationEnabled = [bool]$selectedBranchMapping.BuildValidationEnabled
+                        }
                     }
                     if (-not $existingBranchState) {
                         $existingBranchState = $existingSetupState.BranchStates | Where-Object { $_.BranchName -ieq $branchName } | Select-Object -First 1
@@ -4725,6 +4780,7 @@ function Invoke-AzDoBranchAwareSetup {
                         -BranchName $branchName `
                         -ExistingDevEnvironment $(if ($existingBranchState) { $existingBranchState.ExistingDevEnvironment } else { $null }) `
                         -DeploymentEnvironments @($(if ($existingBranchState) { $existingBranchState.DeploymentEnvironments } else { @() })) `
+                        -BuildValidationEnabled $(if ($existingBranchState) { [bool]$existingBranchState.BuildValidationEnabled } else { $false }) `
                         -PublishPlan $publishPlan
                 }
 
@@ -4757,6 +4813,9 @@ function Invoke-AzDoBranchAwareSetup {
 
                     $existingBranchState.DevEnvironmentConfiguration = $mappedBranch.DevEnvironmentConfiguration
                     $existingBranchState.DeploymentEnvironments = @($mappedBranch.Environments)
+                    if ($mappedBranch.PSObject.Properties.Name -contains 'BuildValidationEnabled') {
+                        $existingBranchState.BuildValidationEnabled = [bool]$mappedBranch.BuildValidationEnabled
+                    }
                     $existingBranchState
                 })
 
@@ -4890,6 +4949,70 @@ function Invoke-AzDoBranchAwareSetup {
             }
         },
         [pscustomobject]@{
+            Name = 'Configure BUILD validation'
+            Action = {
+                Write-Section `
+                    -Message 'Configure solution validation during BUILD'
+                Write-SetupGuidance -Lines @(
+                    'When enabled for a branch, BUILD will run Dataverse connect first (same connection/auth flow as EXPORT) and then run solution validation.',
+                    'Each enabled branch needs a DEV environment configuration so setup can wire credentials and environment URL.'
+                ) -DocRelativePath 'docs/usage/building-releases.md' -Ref $ALM4DataverseRef -Header 'Build validation guidance'
+
+                foreach ($branchState in @($wizardState.BranchStates)) {
+                    $enablePrompt = "Enable solution validation during BUILD for branch '$($branchState.BranchName)'?"
+                    $enableBuildValidation = if ([bool]$branchState.BuildValidationEnabled) {
+                        Read-YesNo -Prompt $enablePrompt
+                    }
+                    else {
+                        Read-YesNo -Prompt $enablePrompt -DefaultNo
+                    }
+
+                    if (-not $enableBuildValidation) {
+                        $branchState.BuildValidationEnabled = $false
+                        continue
+                    }
+
+                    if (-not $branchState.DevEnvironmentConfiguration -and $branchState.ExistingDevEnvironment) {
+                        $branchState.DevEnvironmentConfiguration = $branchState.ExistingDevEnvironment
+                    }
+
+                    if (-not $branchState.DevEnvironmentConfiguration) {
+                        Write-Section `
+                            -Message "BUILD validation requires DEV environment configuration for branch '$($branchState.BranchName)'"
+
+                        $selectedDevEnvironment = Select-DataverseEnvironment -Prompt "Select the DEV environment for BUILD validation on branch '$($branchState.BranchName)'"
+                        if (-not $selectedDevEnvironment) {
+                            throw "BUILD validation was enabled for branch '$($branchState.BranchName)', but no DEV environment was selected."
+                        }
+
+                        $branchState.DevEnvironmentConfiguration = Invoke-WithErrorHandling -OperationName "Selecting DEV environment credentials for BUILD validation on branch '$($branchState.BranchName)'" -ScriptBlock {
+                            Get-AzDoEnvironmentConfiguration `
+                                -EnvironmentName "Dev-$($branchState.BranchName)" `
+                                -EnvironmentUrl (ConvertTo-NormalizedEnvironmentUrl -Url $selectedDevEnvironment.Endpoints['WebApplication']) `
+                                -FriendlyName $selectedDevEnvironment.FriendlyName `
+                                -ExistingCredentials $credentialsCache `
+                                -ExistingServiceAccounts $serviceAccountsCache `
+                                -TenantId $TenantId `
+                                -ProjectName $SelectedProject.Name `
+                                -OrganizationId $OrganizationId `
+                                -OrganizationName $OrganizationName `
+                                -UseAlm4DataverseExtension $UseAlm4DataverseExtension `
+                                -IsDevelopmentEnvironment $true
+                        }
+
+                        if ($branchState.DevEnvironmentConfiguration -and -not ($credentialsCache | Where-Object { $_.ApplicationId -eq $branchState.DevEnvironmentConfiguration.Credentials.ApplicationId -and $_.TenantId -eq $branchState.DevEnvironmentConfiguration.Credentials.TenantId })) {
+                            $credentialsCache += $branchState.DevEnvironmentConfiguration.Credentials
+                        }
+                        if ($branchState.DevEnvironmentConfiguration -and $serviceAccountsCache -notcontains $branchState.DevEnvironmentConfiguration.ServiceAccountUPN) {
+                            $serviceAccountsCache += $branchState.DevEnvironmentConfiguration.ServiceAccountUPN
+                        }
+                    }
+
+                    $branchState.BuildValidationEnabled = $true
+                }
+            }
+        },
+        [pscustomobject]@{
             Name = 'Select solutions'
             Action = {
                 Write-Section `
@@ -4964,6 +5087,7 @@ function Invoke-AzDoBranchAwareSetup {
                     'Main repository'      = $MainRepo.Name
                     'Shared repository'    = $SharedRepositoryName
                     'Configured branches'  = [string]$wizardState.BranchStates.Count
+                    'BUILD validation enabled branches' = [string]@($wizardState.BranchStates | Where-Object { $_.BuildValidationEnabled }).Count
                     'Solution source branch' = $(if ([string]::IsNullOrWhiteSpace($wizardState.SolutionSourceBranch)) { '<none>' } else { $wizardState.SolutionSourceBranch })
                     'Solutions selected'   = [string]$(if ($wizardState.SolutionData) { @($wizardState.SolutionData.Solutions).Count } else { 0 })
                     'Extension mode'       = $(if ($UseAlm4DataverseExtension) { 'ALM4Dataverse extension enabled' } else { 'ALM4Dataverse extension disabled' })
@@ -5045,7 +5169,8 @@ try {
                 -SharedRepositoryName $sharedRepoName `
                 -UseAlm4DataverseExtension $script:useAlm4DataverseExtension `
                 -Solutions $(if ($solutionData) { @($solutions) } else { $null }) `
-                -DeploymentEnvironments @($branchState.DeploymentEnvironments)
+                -DeploymentEnvironments @($branchState.DeploymentEnvironments) `
+                -BuildValidationEnabled ([bool]$branchState.BuildValidationEnabled)
         }
 
         $repoPublishResults += $publishResult

--- a/setup-azdo.ps1
+++ b/setup-azdo.ps1
@@ -3254,14 +3254,20 @@ function Get-DataverseSolutionsSelection {
 function Update-AlmConfigInWorkingTree {
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory)][array]$Solutions,
+        [Parameter()][AllowNull()][array]$Solutions,
         [Parameter(Mandatory)][bool]$BuildValidationEnabled,
         [Parameter(Mandatory)][string]$RepoRoot
     )
 
     $configPath = Join-Path $RepoRoot 'alm-config.psd1'
     $templatePath = if ($PSScriptRoot) { Join-Path $PSScriptRoot 'copy-to-your-repo\alm-config.psd1' } else { $null }
-    $solutionsChanged = Set-AlmConfigSolutionsInFile -ConfigPath $configPath -Solutions $Solutions -CreateIfMissing -TemplatePath $templatePath
+    $solutionsChanged = $false
+    if ($null -ne $Solutions) {
+        $solutionsChanged = Set-AlmConfigSolutionsInFile -ConfigPath $configPath -Solutions @($Solutions) -CreateIfMissing -TemplatePath $templatePath
+    }
+    else {
+        Write-Host 'Skipping solution list updates in alm-config.psd1 because solution selection was not run.' -ForegroundColor Yellow
+    }
     $solutionCheckChanged = Set-AlmConfigSolutionCheckEnabledInFile -ConfigPath $configPath -Enabled $BuildValidationEnabled -CreateIfMissing -TemplatePath $templatePath
     $changed = ($solutionsChanged -or $solutionCheckChanged)
 
@@ -3651,6 +3657,64 @@ function Get-AzDoDeploymentEnvironmentNamesFromPipelineContent {
     return @($environmentNames)
 }
 
+function Get-AzDoBuildEnvironmentNameFromPipelineContent {
+    [CmdletBinding()]
+    param(
+        [Parameter()][string]$PipelineContent
+    )
+
+    if ([string]::IsNullOrWhiteSpace($PipelineContent)) {
+        return $null
+    }
+
+    $match = [regex]::Match($PipelineContent, '(?mi)^\s*buildEnvironmentName\s*:\s*[''\"]?(?<name>[^''\"\r\n]*)[''\"]?\s*$')
+    if (-not $match.Success) {
+        return $null
+    }
+
+    $value = [string]$match.Groups['name'].Value
+    if ([string]::IsNullOrWhiteSpace($value)) {
+        return $null
+    }
+
+    return $value.Trim()
+}
+
+function Get-SolutionCheckEnabledFromConfigContent {
+    [CmdletBinding()]
+    param(
+        [Parameter()][string]$ConfigContent
+    )
+
+    if ([string]::IsNullOrWhiteSpace($ConfigContent)) {
+        return $false
+    }
+
+    $match = [regex]::Match($ConfigContent, '(?mis)solutionCheck\s*=\s*@\{.*?\benabled\s*=\s*\$(true|false)')
+    if (-not $match.Success) {
+        return $false
+    }
+
+    return ($match.Groups[1].Value -ieq 'true')
+}
+
+function Get-AzDoBuildValidationEnabledFromRepoClone {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$RepoRoot,
+        [Parameter(Mandatory)][string]$Branch
+    )
+
+    $buildPipelineContent = Get-GitRepoFileContentFromRemoteBranch -RepoRoot $RepoRoot -Branch $Branch -RelativePath 'pipelines/BUILD.yml'
+    $buildEnvironmentName = Get-AzDoBuildEnvironmentNameFromPipelineContent -PipelineContent $buildPipelineContent
+    $hasBuildEnvironmentAssociation = -not [string]::IsNullOrWhiteSpace($buildEnvironmentName)
+
+    $almConfigContent = Get-GitRepoFileContentFromRemoteBranch -RepoRoot $RepoRoot -Branch $Branch -RelativePath 'alm-config.psd1'
+    $solutionCheckEnabled = Get-SolutionCheckEnabledFromConfigContent -ConfigContent $almConfigContent
+
+    return ($hasBuildEnvironmentAssociation -or $solutionCheckEnabled)
+}
+
 function Get-AzDoDeployPipelineBranchMappingsFromRepoClone {
     [CmdletBinding()]
     param(
@@ -3729,6 +3793,13 @@ function Get-AzDoRepositoryExistingSetupState {
     )
 
     $pipelineBranchMappings = @(Get-AzDoDeployPipelineBranchMappingsFromRepoClone -RepoRoot $RepoRoot)
+    $defaultBranchBuildValidationEnabled = Get-AzDoBuildValidationEnabledFromRepoClone -RepoRoot $RepoRoot -Branch $DefaultBranch
+    $defaultBranchBuildPipelineContent = Get-GitRepoFileContentFromRemoteBranch -RepoRoot $RepoRoot -Branch $DefaultBranch -RelativePath 'pipelines/BUILD.yml'
+    $defaultBranchBuildEnvironmentName = Get-AzDoBuildEnvironmentNameFromPipelineContent -PipelineContent $defaultBranchBuildPipelineContent
+    $existingBuildValidationEnvironment = $null
+    if (-not [string]::IsNullOrWhiteSpace($defaultBranchBuildEnvironmentName)) {
+        $existingBuildValidationEnvironment = Get-AzDoExistingEnvironmentState -ProjectName $ProjectName -EnvironmentName $defaultBranchBuildEnvironmentName -TenantId $TenantId
+    }
     $registeredBranches = @(Get-AzDoRegisteredDeployPipelineBranches -ProjectName $ProjectName)
     $branchNames = @($pipelineBranchMappings | ForEach-Object { [string]$_.BranchName }) + $registeredBranches
     if ($branchNames.Count -eq 0) {
@@ -3797,6 +3868,9 @@ function Get-AzDoRepositoryExistingSetupState {
 
     return [pscustomobject]@{
         BranchStates = @($branchStates)
+        BuildValidationEnabled = [bool]$defaultBranchBuildValidationEnabled
+        BuildValidationEnvironmentName = $defaultBranchBuildEnvironmentName
+        ExistingBuildValidationEnvironment = $existingBuildValidationEnvironment
     }
 }
 
@@ -3837,7 +3911,6 @@ function New-AzDoBranchSetupState {
         [Parameter(Mandatory)][string]$BranchName,
         [Parameter()][object]$ExistingDevEnvironment,
         [Parameter()][array]$DeploymentEnvironments,
-        [Parameter()][bool]$BuildValidationEnabled = $false,
         [Parameter()][object]$PublishPlan
     )
 
@@ -3848,7 +3921,6 @@ function New-AzDoBranchSetupState {
         ExistingDevEnvironment      = $ExistingDevEnvironment
         DevEnvironmentConfiguration = $null
         DeploymentEnvironments      = $normalizedDeploymentEnvironments
-        BuildValidationEnabled      = $BuildValidationEnabled
         PublishPlan                 = $PublishPlan
     }
 }
@@ -4312,9 +4384,10 @@ function Publish-AzDoBranchSetupChanges {
         [Parameter(Mandatory)][string]$CopyRoot,
         [Parameter(Mandatory)][string]$SharedRepositoryName,
         [Parameter(Mandatory)][bool]$UseAlm4DataverseExtension,
-        [Parameter()][array]$Solutions,
+        [Parameter()][AllowNull()][array]$Solutions,
         [Parameter()][array]$DeploymentEnvironments,
-        [Parameter()][bool]$BuildValidationEnabled = $false
+        [Parameter()][bool]$BuildValidationEnabled = $false,
+        [Parameter()][string]$BuildValidationEnvironmentName = ''
     )
 
     Push-Location $RepoRoot
@@ -4415,10 +4488,9 @@ function Publish-AzDoBranchSetupChanges {
             -Branch $ConfiguredBranch `
             -UseAlm4DataverseExtension $UseAlm4DataverseExtension
 
-        $effectiveSolutions = if ($null -ne $Solutions) { @($Solutions) } else { @() }
-        [void](Update-AlmConfigInWorkingTree -Solutions $effectiveSolutions -BuildValidationEnabled $BuildValidationEnabled -RepoRoot $RepoRoot)
+        [void](Update-AlmConfigInWorkingTree -Solutions $Solutions -BuildValidationEnabled $BuildValidationEnabled -RepoRoot $RepoRoot)
 
-        $buildEnvironmentName = if ($BuildValidationEnabled) { "Dev-$ConfiguredBranch" } else { '' }
+        $buildEnvironmentName = if ($BuildValidationEnabled) { [string]$BuildValidationEnvironmentName } else { '' }
         Update-AzDoBuildPipelineInWorkingTree `
             -RepoRoot $RepoRoot `
             -SharedRepositoryName $SharedRepositoryName `
@@ -4617,6 +4689,8 @@ function Invoke-AzDoBranchAwareSetup {
         SolutionData         = $null
         SolutionSourceBranch = $null
         BranchEnvironmentMappingCompleted = $false
+        BuildValidationEnabled = [bool](Get-OptionalObjectPropertyValue -InputObject $existingSetupState -PropertyName 'BuildValidationEnabled')
+        BuildValidationEnvironmentConfiguration = (Get-OptionalObjectPropertyValue -InputObject $existingSetupState -PropertyName 'ExistingBuildValidationEnvironment')
     }
 
     Invoke-SetupWizard -Title 'Azure DevOps ALM4Dataverse setup' -Steps @(
@@ -4630,7 +4704,6 @@ function Invoke-AzDoBranchAwareSetup {
                         DevEnvironmentConfiguration = $_.DevEnvironmentConfiguration
                         ExistingDevEnvironment      = $_.ExistingDevEnvironment
                         Environments                = @($_.DeploymentEnvironments)
-                        BuildValidationEnabled      = [bool]$_.BuildValidationEnabled
                     }
                 })
 
@@ -4754,9 +4827,6 @@ function Invoke-AzDoBranchAwareSetup {
                         $existingBranchState = $existingStateByBranch[$branchKey]
                         $existingBranchState.DevEnvironmentConfiguration = $selectedBranchMapping.DevEnvironmentConfiguration
                         $existingBranchState.DeploymentEnvironments = @($selectedBranchMapping.Environments)
-                        if ($selectedBranchMapping.PSObject.Properties.Name -contains 'BuildValidationEnabled') {
-                            $existingBranchState.BuildValidationEnabled = [bool]$selectedBranchMapping.BuildValidationEnabled
-                        }
                     }
                     if (-not $existingBranchState) {
                         $existingBranchState = $existingSetupState.BranchStates | Where-Object { $_.BranchName -ieq $branchName } | Select-Object -First 1
@@ -4780,7 +4850,6 @@ function Invoke-AzDoBranchAwareSetup {
                         -BranchName $branchName `
                         -ExistingDevEnvironment $(if ($existingBranchState) { $existingBranchState.ExistingDevEnvironment } else { $null }) `
                         -DeploymentEnvironments @($(if ($existingBranchState) { $existingBranchState.DeploymentEnvironments } else { @() })) `
-                        -BuildValidationEnabled $(if ($existingBranchState) { [bool]$existingBranchState.BuildValidationEnabled } else { $false }) `
                         -PublishPlan $publishPlan
                 }
 
@@ -4813,9 +4882,6 @@ function Invoke-AzDoBranchAwareSetup {
 
                     $existingBranchState.DevEnvironmentConfiguration = $mappedBranch.DevEnvironmentConfiguration
                     $existingBranchState.DeploymentEnvironments = @($mappedBranch.Environments)
-                    if ($mappedBranch.PSObject.Properties.Name -contains 'BuildValidationEnabled') {
-                        $existingBranchState.BuildValidationEnabled = [bool]$mappedBranch.BuildValidationEnabled
-                    }
                     $existingBranchState
                 })
 
@@ -4954,62 +5020,65 @@ function Invoke-AzDoBranchAwareSetup {
                 Write-Section `
                     -Message 'Configure solution validation during BUILD'
                 Write-SetupGuidance -Lines @(
-                    'When enabled for a branch, BUILD will run Dataverse connect first (same connection/auth flow as EXPORT) and then run solution validation.',
-                    'Each enabled branch needs a DEV environment configuration so setup can wire credentials and environment URL.'
+                    'When enabled, BUILD will run Dataverse connect first (same connection/auth flow as EXPORT) and then run solution validation.',
+                    'This is a global setup choice: one environment configuration is used for BUILD across all configured branches.'
                 ) -DocRelativePath 'docs/usage/building-releases.md' -Ref $ALM4DataverseRef -Header 'Build validation guidance'
 
-                foreach ($branchState in @($wizardState.BranchStates)) {
-                    $enablePrompt = "Enable solution validation during BUILD for branch '$($branchState.BranchName)'?"
-                    $enableBuildValidation = if ([bool]$branchState.BuildValidationEnabled) {
-                        Read-YesNo -Prompt $enablePrompt
-                    }
-                    else {
-                        Read-YesNo -Prompt $enablePrompt -DefaultNo
-                    }
-
-                    if (-not $enableBuildValidation) {
-                        $branchState.BuildValidationEnabled = $false
-                        continue
-                    }
-
-                    if (-not $branchState.DevEnvironmentConfiguration -and $branchState.ExistingDevEnvironment) {
-                        $branchState.DevEnvironmentConfiguration = $branchState.ExistingDevEnvironment
-                    }
-
-                    if (-not $branchState.DevEnvironmentConfiguration) {
-                        Write-Section `
-                            -Message "BUILD validation requires DEV environment configuration for branch '$($branchState.BranchName)'"
-
-                        $selectedDevEnvironment = Select-DataverseEnvironment -Prompt "Select the DEV environment for BUILD validation on branch '$($branchState.BranchName)'"
-                        if (-not $selectedDevEnvironment) {
-                            throw "BUILD validation was enabled for branch '$($branchState.BranchName)', but no DEV environment was selected."
-                        }
-
-                        $branchState.DevEnvironmentConfiguration = Invoke-WithErrorHandling -OperationName "Selecting DEV environment credentials for BUILD validation on branch '$($branchState.BranchName)'" -ScriptBlock {
-                            Get-AzDoEnvironmentConfiguration `
-                                -EnvironmentName "Dev-$($branchState.BranchName)" `
-                                -EnvironmentUrl (ConvertTo-NormalizedEnvironmentUrl -Url $selectedDevEnvironment.Endpoints['WebApplication']) `
-                                -FriendlyName $selectedDevEnvironment.FriendlyName `
-                                -ExistingCredentials $credentialsCache `
-                                -ExistingServiceAccounts $serviceAccountsCache `
-                                -TenantId $TenantId `
-                                -ProjectName $SelectedProject.Name `
-                                -OrganizationId $OrganizationId `
-                                -OrganizationName $OrganizationName `
-                                -UseAlm4DataverseExtension $UseAlm4DataverseExtension `
-                                -IsDevelopmentEnvironment $true
-                        }
-
-                        if ($branchState.DevEnvironmentConfiguration -and -not ($credentialsCache | Where-Object { $_.ApplicationId -eq $branchState.DevEnvironmentConfiguration.Credentials.ApplicationId -and $_.TenantId -eq $branchState.DevEnvironmentConfiguration.Credentials.TenantId })) {
-                            $credentialsCache += $branchState.DevEnvironmentConfiguration.Credentials
-                        }
-                        if ($branchState.DevEnvironmentConfiguration -and $serviceAccountsCache -notcontains $branchState.DevEnvironmentConfiguration.ServiceAccountUPN) {
-                            $serviceAccountsCache += $branchState.DevEnvironmentConfiguration.ServiceAccountUPN
-                        }
-                    }
-
-                    $branchState.BuildValidationEnabled = $true
+                $enableBuildValidation = if ([bool]$wizardState.BuildValidationEnabled) {
+                    Read-YesNo -Prompt 'Enable solution validation during BUILD?'
                 }
+                else {
+                    Read-YesNo -Prompt 'Enable solution validation during BUILD?' -DefaultNo
+                }
+
+                if (-not $enableBuildValidation) {
+                    $wizardState.BuildValidationEnabled = $false
+                    $wizardState.BuildValidationEnvironmentConfiguration = $null
+                    return
+                }
+
+                $existingBuildValidationEnvironment = $wizardState.BuildValidationEnvironmentConfiguration
+                $existingBuildValidationEnvironmentUrl = [string](Get-OptionalObjectPropertyValue -InputObject $existingBuildValidationEnvironment -PropertyName 'Url')
+                $existingBuildValidationEnvironmentName = [string](Get-OptionalObjectPropertyValue -InputObject $existingBuildValidationEnvironment -PropertyName 'ShortName')
+                $existingBuildValidationEnvironmentFriendlyName = [string](Get-OptionalObjectPropertyValue -InputObject $existingBuildValidationEnvironment -PropertyName 'FriendlyName')
+                $existingBuildValidationCredential = Get-OptionalObjectPropertyValue -InputObject $existingBuildValidationEnvironment -PropertyName 'Credentials'
+                $existingBuildValidationServiceAccountUPN = [string](Get-OptionalObjectPropertyValue -InputObject $existingBuildValidationEnvironment -PropertyName 'ServiceAccountUPN')
+
+                $selectedBuildEnvironment = Select-DataverseEnvironment -Prompt 'Select the Dataverse environment for global BUILD validation' -PreferredUrl $existingBuildValidationEnvironmentUrl
+                if (-not $selectedBuildEnvironment) {
+                    throw 'BUILD validation was enabled, but no Dataverse environment was selected.'
+                }
+
+                $buildValidationEnvironmentName = Read-TextWithDefault -Prompt 'Enter the Azure DevOps service connection name for BUILD validation' -DefaultValue $(if ([string]::IsNullOrWhiteSpace($existingBuildValidationEnvironmentName)) { 'Build' } else { $existingBuildValidationEnvironmentName })
+                if ([string]::IsNullOrWhiteSpace($buildValidationEnvironmentName)) {
+                    throw 'A service connection name is required for global BUILD validation.'
+                }
+
+                $wizardState.BuildValidationEnvironmentConfiguration = Invoke-WithErrorHandling -OperationName 'Selecting global BUILD validation environment credentials' -ScriptBlock {
+                    Get-AzDoEnvironmentConfiguration `
+                        -EnvironmentName $buildValidationEnvironmentName `
+                        -EnvironmentUrl (ConvertTo-NormalizedEnvironmentUrl -Url $selectedBuildEnvironment.Endpoints['WebApplication']) `
+                        -FriendlyName $(if ([string]::IsNullOrWhiteSpace($selectedBuildEnvironment.FriendlyName)) { $existingBuildValidationEnvironmentFriendlyName } else { $selectedBuildEnvironment.FriendlyName }) `
+                        -ExistingCredentials $credentialsCache `
+                        -ExistingServiceAccounts $serviceAccountsCache `
+                        -TenantId $TenantId `
+                        -ProjectName $SelectedProject.Name `
+                        -OrganizationId $OrganizationId `
+                        -OrganizationName $OrganizationName `
+                        -UseAlm4DataverseExtension $UseAlm4DataverseExtension `
+                        -ExistingCredential $existingBuildValidationCredential `
+                        -ExistingServiceAccountUPN $existingBuildValidationServiceAccountUPN `
+                        -IsDevelopmentEnvironment $false
+                }
+
+                if ($wizardState.BuildValidationEnvironmentConfiguration -and -not ($credentialsCache | Where-Object { $_.ApplicationId -eq $wizardState.BuildValidationEnvironmentConfiguration.Credentials.ApplicationId -and $_.TenantId -eq $wizardState.BuildValidationEnvironmentConfiguration.Credentials.TenantId })) {
+                    $credentialsCache += $wizardState.BuildValidationEnvironmentConfiguration.Credentials
+                }
+                if ($wizardState.BuildValidationEnvironmentConfiguration -and $serviceAccountsCache -notcontains $wizardState.BuildValidationEnvironmentConfiguration.ServiceAccountUPN) {
+                    $serviceAccountsCache += $wizardState.BuildValidationEnvironmentConfiguration.ServiceAccountUPN
+                }
+
+                $wizardState.BuildValidationEnabled = $true
             }
         },
         [pscustomobject]@{
@@ -5087,7 +5156,8 @@ function Invoke-AzDoBranchAwareSetup {
                     'Main repository'      = $MainRepo.Name
                     'Shared repository'    = $SharedRepositoryName
                     'Configured branches'  = [string]$wizardState.BranchStates.Count
-                    'BUILD validation enabled branches' = [string]@($wizardState.BranchStates | Where-Object { $_.BuildValidationEnabled }).Count
+                    'BUILD validation'     = $(if ($wizardState.BuildValidationEnabled) { 'Enabled' } else { 'Disabled' })
+                    'BUILD validation environment' = $(if ($wizardState.BuildValidationEnvironmentConfiguration) { $wizardState.BuildValidationEnvironmentConfiguration.ShortName } else { '<none>' })
                     'Solution source branch' = $(if ([string]::IsNullOrWhiteSpace($wizardState.SolutionSourceBranch)) { '<none>' } else { $wizardState.SolutionSourceBranch })
                     'Solutions selected'   = [string]$(if ($wizardState.SolutionData) { @($wizardState.SolutionData.Solutions).Count } else { 0 })
                     'Extension mode'       = $(if ($UseAlm4DataverseExtension) { 'ALM4Dataverse extension enabled' } else { 'ALM4Dataverse extension disabled' })
@@ -5109,6 +5179,8 @@ function Invoke-AzDoBranchAwareSetup {
         BranchStates         = @($wizardState.BranchStates)
         SolutionData         = $wizardState.SolutionData
         SolutionSourceBranch = $wizardState.SolutionSourceBranch
+        BuildValidationEnabled = [bool]$wizardState.BuildValidationEnabled
+        BuildValidationEnvironmentConfiguration = $wizardState.BuildValidationEnvironmentConfiguration
     }
 }
 
@@ -5127,6 +5199,8 @@ $azDoSetupResult = Invoke-AzDoBranchAwareSetup `
 $branchStates = @($azDoSetupResult.BranchStates)
 $solutionData = $azDoSetupResult.SolutionData
 $solutionSourceBranch = $azDoSetupResult.SolutionSourceBranch
+$buildValidationEnabled = [bool](Get-OptionalObjectPropertyValue -InputObject $azDoSetupResult -PropertyName 'BuildValidationEnabled')
+$buildValidationEnvironmentConfiguration = Get-OptionalObjectPropertyValue -InputObject $azDoSetupResult -PropertyName 'BuildValidationEnvironmentConfiguration'
 $solutions = if ($solutionData) { @($solutionData.Solutions) } else { @() }
 $allConfiguredEnvironments = @()
 foreach ($branchState in @($branchStates)) {
@@ -5170,7 +5244,8 @@ try {
                 -UseAlm4DataverseExtension $script:useAlm4DataverseExtension `
                 -Solutions $(if ($solutionData) { @($solutions) } else { $null }) `
                 -DeploymentEnvironments @($branchState.DeploymentEnvironments) `
-                -BuildValidationEnabled ([bool]$branchState.BuildValidationEnabled)
+                -BuildValidationEnabled $buildValidationEnabled `
+                -BuildValidationEnvironmentName $(if ($buildValidationEnvironmentConfiguration) { [string]$buildValidationEnvironmentConfiguration.ShortName } else { '' })
         }
 
         $repoPublishResults += $publishResult
@@ -5220,6 +5295,7 @@ Invoke-WithErrorHandling -OperationName 'Authorizing Pipelines for Repositories'
 
 $pipelineFolder = "\$($mainRepo.Name)"
 $allPipelines = Get-VSTeamBuildDefinition -ProjectName $selectedProject.Name
+$buildPipeline = $allPipelines | Where-Object { $_.name -eq 'BUILD' -and $_.path -eq $pipelineFolder } | Select-Object -First 1
 $exportPipeline = $allPipelines | Where-Object { $_.name -eq 'EXPORT' -and $_.path -eq $pipelineFolder } | Select-Object -First 1
 $deployPipelinesByBranch = @{}
 foreach ($branchState in @($branchStates)) {
@@ -5234,6 +5310,7 @@ foreach ($branchState in @($branchStates)) {
 }
 
 if (-not $exportPipeline) { Write-Warning 'EXPORT pipeline not found. Skipping some DEV authorizations.' }
+if ($buildValidationEnabled -and -not $buildPipeline) { Write-Warning 'BUILD pipeline not found. Skipping some global BUILD validation authorizations.' }
 
 Write-Section `
     -Message 'Configure DEV environments'
@@ -5260,6 +5337,28 @@ else {
                 -UseAlm4DataverseExtension $script:useAlm4DataverseExtension
         } -StatusMessage "Applying DEV environment configuration for branch '$($branchState.BranchName)'..." -CaptureOutputInPanel | Out-Null
     }
+}
+
+Write-Section `
+    -Message 'Configure global BUILD validation environment'
+
+if (-not $buildValidationEnabled -or -not $buildValidationEnvironmentConfiguration) {
+    [Spectre.Console.AnsiConsole]::MarkupLine('[yellow]Global BUILD validation is disabled, so BUILD environment configuration will be skipped.[/]')
+}
+elseif (-not $buildPipeline) {
+    [Spectre.Console.AnsiConsole]::MarkupLine('[yellow]BUILD pipeline was not found, so BUILD environment configuration could not be applied.[/]')
+}
+else {
+    Invoke-WithErrorHandling -OperationName 'Applying global BUILD validation environment configuration' -AllowSkip -ScriptBlock {
+        Apply-AzDoEnvironmentConfiguration `
+            -EnvironmentConfiguration $buildValidationEnvironmentConfiguration `
+            -OrganizationName $orgName `
+            -ProjectName $selectedProject.Name `
+            -ProjectId $selectedProject.Id `
+            -ExportPipeline $null `
+            -DeployPipeline $buildPipeline `
+            -UseAlm4DataverseExtension $script:useAlm4DataverseExtension
+    } -StatusMessage 'Applying global BUILD validation environment configuration...' -CaptureOutputInPanel | Out-Null
 }
 
 Write-Section `

--- a/setup-common.ps1
+++ b/setup-common.ps1
@@ -90,6 +90,32 @@ function ConvertTo-SpectreMarkupLiteral {
     return ([string]$Text).Replace('[', '[[').Replace(']', ']]')
 }
 
+function Get-OptionalObjectPropertyValue {
+    [CmdletBinding()]
+    param(
+        [Parameter()][object]$InputObject,
+        [Parameter(Mandatory)][string]$PropertyName
+    )
+
+    if ($null -eq $InputObject) {
+        return $null
+    }
+
+    if ($InputObject -is [hashtable]) {
+        if ($InputObject.ContainsKey($PropertyName)) {
+            return $InputObject[$PropertyName]
+        }
+
+        return $null
+    }
+
+    if ($InputObject.PSObject -and $InputObject.PSObject.Properties.Name -contains $PropertyName) {
+        return $InputObject.$PropertyName
+    }
+
+    return $null
+}
+
 function Invoke-GenericStaticMethod {
     [CmdletBinding()]
     param(

--- a/setup-common.ps1
+++ b/setup-common.ps1
@@ -1151,14 +1151,35 @@ function Select-FromMenu {
         $prompt.SearchPlaceholderText = '[grey]Start typing to filter options[/]'
     }
 
+    $effectiveDisplayItems = @()
     foreach ($item in $effectiveItems) {
-        [void]$prompt.AddChoice($item)
+        $effectiveDisplayItems += [string](ConvertTo-SpectreMarkupLiteral -Text $item)
+    }
+
+    foreach ($displayItem in $effectiveDisplayItems) {
+        [void]$prompt.AddChoice($displayItem)
     }
 
     Show-SetupStatusBarAtBottom -PromptKind 'Menu' -SearchEnabled:$prompt.SearchEnabled
 
     try {
-        $selectedValue = Show-SelectionPromptWithInterruptHandling -Prompt $prompt
+        $selectedDisplayValue = Show-SelectionPromptWithInterruptHandling -Prompt $prompt
+        Write-SetupDebug -Message "SelectionPrompt selected display value: '$selectedDisplayValue'"
+
+        $selectedEffectiveIndex = -1
+        for ($effectiveIndex = 0; $effectiveIndex -lt $effectiveDisplayItems.Count; $effectiveIndex++) {
+            if ($effectiveDisplayItems[$effectiveIndex] -ceq $selectedDisplayValue) {
+                $selectedEffectiveIndex = $effectiveIndex
+                break
+            }
+        }
+
+        if ($selectedEffectiveIndex -lt 0) {
+            Write-SetupDebug -Message "SelectionPrompt display value '$selectedDisplayValue' did not map to a known item."
+            return $null
+        }
+
+        $selectedValue = [string]$effectiveItems[$selectedEffectiveIndex]
         Write-SetupDebug -Message "SelectionPrompt selected value: '$selectedValue'"
 
         if ($singleChoiceCancelLabel -and $selectedValue -ceq $singleChoiceCancelLabel) {

--- a/setup-common.ps1
+++ b/setup-common.ps1
@@ -1990,6 +1990,72 @@ function Set-AlmConfigSolutionsInFile {
     return $hasChanges
 }
 
+function Set-AlmConfigSolutionCheckEnabledInFile {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$ConfigPath,
+        [Parameter(Mandatory)][bool]$Enabled,
+        [Parameter()][switch]$CreateIfMissing,
+        [Parameter()][string]$TemplatePath
+    )
+
+    if (-not (Test-Path -LiteralPath $ConfigPath)) {
+        if (-not $CreateIfMissing) {
+            throw "alm-config.psd1 not found: $ConfigPath"
+        }
+
+        if (-not [string]::IsNullOrWhiteSpace($TemplatePath) -and (Test-Path -LiteralPath $TemplatePath)) {
+            Copy-Item -LiteralPath $TemplatePath -Destination $ConfigPath -Force
+        }
+        else {
+            Set-Content -LiteralPath $ConfigPath -Value "@{`n}`n" -NoNewline
+        }
+    }
+
+    $configContent = Get-Content -LiteralPath $ConfigPath -Raw
+    $enabledLiteral = if ($Enabled) { '$true' } else { '$false' }
+    $solutionCheckBlock = "@{`n        enabled = $enabledLiteral`n    }"
+
+    $tokens = $null
+    $parseErrors = $null
+    $ast = [System.Management.Automation.Language.Parser]::ParseInput($configContent, [ref]$tokens, [ref]$parseErrors)
+    if ($parseErrors -and $parseErrors.Count -gt 0) {
+        throw "Could not parse existing alm-config.psd1 '$ConfigPath': $($parseErrors[0].Message)"
+    }
+
+    $rootHashtable = $ast.Find({
+        param($node)
+        $node -is [System.Management.Automation.Language.HashtableAst]
+    }, $false)
+
+    if (-not $rootHashtable) {
+        throw "Could not find the root hashtable in '$ConfigPath'."
+    }
+
+    $solutionCheckEntry = $rootHashtable.KeyValuePairs | Where-Object {
+        $keyText = $_.Item1.Extent.Text.Trim()
+        $keyText -in @('solutionCheck', "'solutionCheck'", '"solutionCheck"')
+    } | Select-Object -First 1
+
+    if ($solutionCheckEntry) {
+        $valueExtent = $solutionCheckEntry.Item2.Extent
+        $updatedContent = $configContent.Substring(0, $valueExtent.StartOffset) + $solutionCheckBlock + $configContent.Substring($valueExtent.EndOffset)
+    }
+    else {
+        $insertOffset = $rootHashtable.Extent.EndOffset - 1
+        $lineEnding = if ($configContent -match "`r`n") { "`r`n" } else { "`n" }
+        $insertText = "$lineEnding    solutionCheck = $solutionCheckBlock$lineEnding"
+        $updatedContent = $configContent.Substring(0, $insertOffset) + $insertText + $configContent.Substring($insertOffset)
+    }
+
+    $hasChanges = ($updatedContent -ne $configContent)
+    if ($hasChanges) {
+        Set-Content -LiteralPath $ConfigPath -Value $updatedContent -NoNewline
+    }
+
+    return $hasChanges
+}
+
 function Select-ConfiguredDeploymentEnvironments {
     [CmdletBinding()]
     param(

--- a/setup-github.ps1
+++ b/setup-github.ps1
@@ -3286,7 +3286,7 @@ function Publish-GitHubBranchSetupChanges {
         [Parameter()][array]$DeploymentEnvironments,
         [Parameter()][array]$DeployWorkflowBranchDefinitions,
         [Parameter()][bool]$BuildValidationEnabled = $false,
-        [Parameter()][string]$BuildValidationEnvironmentName = '',
+        [Parameter()][AllowEmptyString()][string]$BuildValidationEnvironmentName = '',
         [Parameter()][switch]$SkipDeployWorkflow
     )
 

--- a/setup-github.ps1
+++ b/setup-github.ps1
@@ -722,6 +722,64 @@ function Get-GitHubDeploymentEnvironmentNamesFromWorkflowContent {
     return @($names)
 }
 
+function Get-GitHubBuildEnvironmentNameFromWorkflowContent {
+    [CmdletBinding()]
+    param(
+        [Parameter()][string]$WorkflowContent
+    )
+
+    if ([string]::IsNullOrWhiteSpace($WorkflowContent)) {
+        return $null
+    }
+
+    $match = [regex]::Match($WorkflowContent, '(?mi)^\s*environment-name\s*:\s*[''\"]?(?<name>[^''\"\r\n]*)[''\"]?\s*$')
+    if (-not $match.Success) {
+        return $null
+    }
+
+    $value = [string]$match.Groups['name'].Value
+    if ([string]::IsNullOrWhiteSpace($value)) {
+        return $null
+    }
+
+    return $value.Trim()
+}
+
+function Get-SolutionCheckEnabledFromConfigContent {
+    [CmdletBinding()]
+    param(
+        [Parameter()][string]$ConfigContent
+    )
+
+    if ([string]::IsNullOrWhiteSpace($ConfigContent)) {
+        return $false
+    }
+
+    $match = [regex]::Match($ConfigContent, '(?mis)solutionCheck\s*=\s*@\{.*?\benabled\s*=\s*\$(true|false)')
+    if (-not $match.Success) {
+        return $false
+    }
+
+    return ($match.Groups[1].Value -ieq 'true')
+}
+
+function Get-GitHubBuildValidationEnabledFromRepoClone {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$RepoRoot,
+        [Parameter(Mandatory)][string]$Branch
+    )
+
+    $buildWorkflowContent = Get-GitRepoFileContentFromRemoteBranch -RepoRoot $RepoRoot -Branch $Branch -RelativePath '.github/workflows/BUILD.yml'
+    $buildEnvironmentName = Get-GitHubBuildEnvironmentNameFromWorkflowContent -WorkflowContent $buildWorkflowContent
+    $hasBuildEnvironmentAssociation = -not [string]::IsNullOrWhiteSpace($buildEnvironmentName)
+
+    $almConfigContent = Get-GitRepoFileContentFromRemoteBranch -RepoRoot $RepoRoot -Branch $Branch -RelativePath 'alm-config.psd1'
+    $solutionCheckEnabled = Get-SolutionCheckEnabledFromConfigContent -ConfigContent $almConfigContent
+
+    return ($hasBuildEnvironmentAssociation -or $solutionCheckEnabled)
+}
+
 function Get-GitRepoFileContentFromRemoteBranch {
     [CmdletBinding()]
     param(
@@ -887,6 +945,7 @@ function Get-GitHubRepositoryExistingSetupState {
     $deploymentEnvironments = @()
     $deploymentBranchMappings = @()
     $storageScope = $null
+    $defaultBranchBuildValidationEnabled = Get-GitHubBuildValidationEnabledFromRepoClone -RepoRoot $RepoRoot -Branch $DefaultBranch
 
     $workflowBranchMappings = @(Get-GitHubDeployWorkflowBranchMappingsFromRepoClone -RepoRoot $RepoRoot)
     foreach ($workflowBranchMapping in $workflowBranchMappings) {
@@ -963,6 +1022,16 @@ function Get-GitHubRepositoryExistingSetupState {
         )
     }
 
+    if ($deploymentBranchMappings.Count -eq 0) {
+        $deploymentBranchMappings = @(
+            [pscustomobject]@{
+                BranchName   = $DefaultBranch
+                Environments = @()
+                SourceBranch = $DefaultBranch
+            }
+        )
+    }
+
     if (-not $storageScope -and $devEnvironment -and $devEnvironment.StorageScope) {
         $storageScope = $devEnvironment.StorageScope
     }
@@ -970,6 +1039,18 @@ function Get-GitHubRepositoryExistingSetupState {
     return [pscustomobject]@{
         SharedWorkflowRepository = $(if ($workflowReference) { $workflowReference.Repository } else { $null })
         SharedWorkflowReference  = $(if ($workflowReference) { $workflowReference.Reference } else { $null })
+        DefaultBranchBuildValidationEnabled = [bool]$defaultBranchBuildValidationEnabled
+        BuildValidationEnabled   = [bool]$defaultBranchBuildValidationEnabled
+        BuildValidationEnvironmentName = (Get-GitHubBuildEnvironmentNameFromWorkflowContent -WorkflowContent (Get-GitRepoFileContentFromRemoteBranch -RepoRoot $RepoRoot -Branch $DefaultBranch -RelativePath '.github/workflows/BUILD.yml'))
+        ExistingBuildValidationEnvironment = $(
+            $buildEnvName = Get-GitHubBuildEnvironmentNameFromWorkflowContent -WorkflowContent (Get-GitRepoFileContentFromRemoteBranch -RepoRoot $RepoRoot -Branch $DefaultBranch -RelativePath '.github/workflows/BUILD.yml')
+            if ([string]::IsNullOrWhiteSpace($buildEnvName)) {
+                $null
+            }
+            else {
+                Get-GitHubExistingEnvironmentState -Owner $RepoOwner -Repo $RepoName -EnvironmentName $buildEnvName -TenantId $TenantId
+            }
+        )
         CredentialStorageScope   = $storageScope
         DevEnvironment           = $devEnvironment
         DeploymentEnvironments   = @($deploymentEnvironments)
@@ -1024,7 +1105,6 @@ function New-GitHubBranchSetupState {
         [Parameter(Mandatory)][string]$BranchName,
         [Parameter()][object]$ExistingDevEnvironment,
         [Parameter()][array]$DeploymentEnvironments,
-        [Parameter()][bool]$BuildValidationEnabled = $false,
         [Parameter()][object]$PublishPlan
     )
 
@@ -1035,7 +1115,6 @@ function New-GitHubBranchSetupState {
         ExistingDevEnvironment      = $ExistingDevEnvironment
         DevEnvironmentConfiguration = $null
         DeploymentEnvironments      = $normalizedDeploymentEnvironments
-        BuildValidationEnabled      = $BuildValidationEnabled
         PublishPlan                 = $PublishPlan
     }
 }
@@ -3206,6 +3285,7 @@ function Publish-GitHubBranchSetupChanges {
         [Parameter()][array]$DeploymentEnvironments,
         [Parameter()][array]$DeployWorkflowBranchDefinitions,
         [Parameter()][bool]$BuildValidationEnabled = $false,
+        [Parameter()][string]$BuildValidationEnvironmentName = '',
         [Parameter()][switch]$SkipDeployWorkflow
     )
 
@@ -3299,7 +3379,7 @@ function Publish-GitHubBranchSetupChanges {
         $effectiveSolutions = if ($Solutions) { @($Solutions) } else { @() }
         Update-AlmConfigInRepoClone -Solutions $effectiveSolutions -BuildValidationEnabled $BuildValidationEnabled -RepoRoot $RepoRoot
 
-        $buildEnvironmentName = if ($BuildValidationEnabled) { "Dev-$ConfiguredBranch" } else { '' }
+        $buildEnvironmentName = if ($BuildValidationEnabled) { [string]$BuildValidationEnvironmentName } else { '' }
         Update-BuildWorkflowInRepoClone `
             -RepoRoot $RepoRoot `
             -SharedWorkflowRepository $SharedWorkflowRepository `
@@ -3452,6 +3532,8 @@ function Invoke-GitHubBranchAwareSetup {
             SolutionResult      = $null
             SolutionSourceBranch = $null
             BranchEnvironmentMappingCompleted = $false
+            BuildValidationEnabled = [bool](Get-OptionalObjectPropertyValue -InputObject $ExistingSetupState -PropertyName 'BuildValidationEnabled')
+            BuildValidationEnvironmentConfiguration = (Get-OptionalObjectPropertyValue -InputObject $ExistingSetupState -PropertyName 'ExistingBuildValidationEnvironment')
         }
 
         Invoke-SetupWizard -Title 'GitHub Actions ALM4Dataverse setup' -Steps @(
@@ -3464,7 +3546,6 @@ function Invoke-GitHubBranchAwareSetup {
                             DevEnvironmentConfiguration = $_.DevEnvironmentConfiguration
                             ExistingDevEnvironment      = $_.ExistingDevEnvironment
                             Environments                = @($_.DeploymentEnvironments)
-                            BuildValidationEnabled      = [bool]$_.BuildValidationEnabled
                         }
                     })
 
@@ -3726,9 +3807,6 @@ function Invoke-GitHubBranchAwareSetup {
                             $existingBranchState = $existingStateByBranch[$branchKey]
                             $existingBranchState.DevEnvironmentConfiguration = $selectedBranchMapping.DevEnvironmentConfiguration
                             $existingBranchState.DeploymentEnvironments = @($selectedBranchMapping.Environments)
-                            if ($selectedBranchMapping.PSObject.Properties.Name -contains 'BuildValidationEnabled') {
-                                $existingBranchState.BuildValidationEnabled = [bool]$selectedBranchMapping.BuildValidationEnabled
-                            }
                             $updatedBranchStates += $existingBranchState
                             continue
                         }
@@ -3743,9 +3821,6 @@ function Invoke-GitHubBranchAwareSetup {
                         $newBranchState = New-GitHubBranchSetupState -BranchName $branchName -ExistingDevEnvironment $existingDevEnvironment -DeploymentEnvironments @()
                         $newBranchState.DevEnvironmentConfiguration = $selectedBranchMapping.DevEnvironmentConfiguration
                         $newBranchState.DeploymentEnvironments = @($selectedBranchMapping.Environments)
-                        if ($selectedBranchMapping.PSObject.Properties.Name -contains 'BuildValidationEnabled') {
-                            $newBranchState.BuildValidationEnabled = [bool]$selectedBranchMapping.BuildValidationEnabled
-                        }
                         $updatedBranchStates += $newBranchState
                     }
 
@@ -3794,9 +3869,6 @@ function Invoke-GitHubBranchAwareSetup {
 
                         $existingBranchState.DevEnvironmentConfiguration = $mappedBranch.DevEnvironmentConfiguration
                         $existingBranchState.DeploymentEnvironments = @($mappedBranch.Environments)
-                        if ($mappedBranch.PSObject.Properties.Name -contains 'BuildValidationEnabled') {
-                            $existingBranchState.BuildValidationEnabled = [bool]$mappedBranch.BuildValidationEnabled
-                        }
                         $existingBranchState
                     })
 
@@ -4164,68 +4236,66 @@ function Invoke-GitHubBranchAwareSetup {
                     Write-Section `
                         -Message 'Configure solution validation during BUILD'
                     Write-SetupGuidance -Lines @(
-                        'When enabled for a branch, BUILD associates with that branch''s DEV environment and runs Dataverse connect before build/validation.',
-                        'If no DEV environment is configured yet, setup will prompt for it now using the same environment/auth flow as EXPORT.'
+                        'When enabled, BUILD uses one global Dataverse environment for pre-build connect/auth and solution validation.',
+                        'This is configured once and then applied across all configured branches.'
                     ) -DocRelativePath 'docs/usage/building-releases.md' -Ref $ALM4DataverseRef -Header 'Build validation guidance'
 
-                    foreach ($branchState in @($wizardState.BranchStates)) {
-                        $branchName = [string]$branchState.BranchName
-                        $enablePrompt = "Enable solution validation during BUILD for branch '$branchName'?"
-                        $enableBuildValidation = if ([bool]$branchState.BuildValidationEnabled) {
-                            Read-YesNo -Prompt $enablePrompt
-                        }
-                        else {
-                            Read-YesNo -Prompt $enablePrompt -DefaultNo
-                        }
-
-                        if (-not $enableBuildValidation) {
-                            $branchState.BuildValidationEnabled = $false
-                            continue
-                        }
-
-                        if (-not $branchState.DevEnvironmentConfiguration -and $branchState.ExistingDevEnvironment) {
-                            $branchState.DevEnvironmentConfiguration = $branchState.ExistingDevEnvironment
-                        }
-
-                        if (-not $branchState.DevEnvironmentConfiguration) {
-                            Write-Section `
-                                -Message "BUILD validation requires a DEV environment for branch '$branchName'"
-
-                            if ($UseGitHubEnvironments) {
-                                Write-Host "Preparing GitHub environment 'Dev-$branchName' for BUILD validation." -ForegroundColor Green
-                            }
-                            else {
-                                Write-Host "Preparing prefixed repo-level credentials for DEV environment 'Dev-$branchName' (BUILD validation)." -ForegroundColor Green
-                            }
-                            Write-Host ''
-
-                            $devEnvSelection = Select-DataverseEnvironment -Prompt "Select the DEV Dataverse environment for branch '$branchName'"
-                            if (-not $devEnvSelection) {
-                                throw "BUILD validation was enabled for branch '$branchName', but no DEV environment was selected."
-                            }
-
-                            $devEnvUrl = ConvertTo-NormalizedEnvironmentUrl -Url $devEnvSelection.Endpoints['WebApplication']
-                            $devEnvFriendlyName = $devEnvSelection.FriendlyName
-
-                            $branchState.DevEnvironmentConfiguration = Get-GitHubEnvironmentConfiguration `
-                                -EnvironmentName "Dev-$branchName" `
-                                -EnvironmentUrl $devEnvUrl `
-                                -FriendlyName $devEnvFriendlyName `
-                                -ExistingCredentials $cachedCredentials `
-                                -ExistingServiceAccounts $cachedServiceAccounts `
-                                -TenantId $TenantId `
-                                -RepoName $RepoName
-
-                            if ($branchState.DevEnvironmentConfiguration -and -not ($cachedCredentials | Where-Object { $_.ApplicationId -eq $branchState.DevEnvironmentConfiguration.Credentials.ApplicationId -and $_.TenantId -eq $branchState.DevEnvironmentConfiguration.Credentials.TenantId })) {
-                                $cachedCredentials += $branchState.DevEnvironmentConfiguration.Credentials
-                            }
-                            if ($branchState.DevEnvironmentConfiguration -and $cachedServiceAccounts -notcontains $branchState.DevEnvironmentConfiguration.ServiceAccountUPN) {
-                                $cachedServiceAccounts += $branchState.DevEnvironmentConfiguration.ServiceAccountUPN
-                            }
-                        }
-
-                        $branchState.BuildValidationEnabled = $true
+                    $enableBuildValidation = if ([bool]$wizardState.BuildValidationEnabled) {
+                        Read-YesNo -Prompt 'Enable solution validation during BUILD?'
                     }
+                    else {
+                        Read-YesNo -Prompt 'Enable solution validation during BUILD?' -DefaultNo
+                    }
+
+                    if (-not $enableBuildValidation) {
+                        $wizardState.BuildValidationEnabled = $false
+                        $wizardState.BuildValidationEnvironmentConfiguration = $null
+                        return
+                    }
+
+                    $existingBuildValidationEnvironment = $wizardState.BuildValidationEnvironmentConfiguration
+                    $existingBuildValidationEnvironmentUrl = [string](Get-OptionalObjectPropertyValue -InputObject $existingBuildValidationEnvironment -PropertyName 'Url')
+                    $existingBuildValidationEnvironmentName = [string](Get-OptionalObjectPropertyValue -InputObject $existingBuildValidationEnvironment -PropertyName 'ShortName')
+                    $existingBuildValidationEnvironmentCredential = Get-OptionalObjectPropertyValue -InputObject $existingBuildValidationEnvironment -PropertyName 'Credentials'
+                    $existingBuildValidationServiceAccountUPN = [string](Get-OptionalObjectPropertyValue -InputObject $existingBuildValidationEnvironment -PropertyName 'ServiceAccountUPN')
+
+                    if ($UseGitHubEnvironments) {
+                        Write-Host 'Preparing a global GitHub environment for BUILD validation.' -ForegroundColor Green
+                    }
+                    else {
+                        Write-Host 'Preparing global prefixed repo-level credentials for BUILD validation.' -ForegroundColor Green
+                    }
+                    Write-Host ''
+
+                    $selectedBuildEnvironment = Select-DataverseEnvironment -Prompt 'Select the Dataverse environment for global BUILD validation' -PreferredUrl $existingBuildValidationEnvironmentUrl
+                    if (-not $selectedBuildEnvironment) {
+                        throw 'BUILD validation was enabled, but no Dataverse environment was selected.'
+                    }
+
+                    $buildValidationEnvironmentName = Read-TextWithDefault -Prompt 'Enter the GitHub environment name for BUILD validation' -DefaultValue $(if ([string]::IsNullOrWhiteSpace($existingBuildValidationEnvironmentName)) { 'Build' } else { $existingBuildValidationEnvironmentName })
+                    if ([string]::IsNullOrWhiteSpace($buildValidationEnvironmentName)) {
+                        throw 'A GitHub environment name is required for global BUILD validation.'
+                    }
+
+                    $wizardState.BuildValidationEnvironmentConfiguration = Get-GitHubEnvironmentConfiguration `
+                        -EnvironmentName $buildValidationEnvironmentName `
+                        -EnvironmentUrl (ConvertTo-NormalizedEnvironmentUrl -Url $selectedBuildEnvironment.Endpoints['WebApplication']) `
+                        -FriendlyName $selectedBuildEnvironment.FriendlyName `
+                        -ExistingCredentials $cachedCredentials `
+                        -ExistingServiceAccounts $cachedServiceAccounts `
+                        -TenantId $TenantId `
+                        -RepoName $RepoName `
+                        -ExistingCredential $existingBuildValidationEnvironmentCredential `
+                        -ExistingServiceAccountUPN $existingBuildValidationServiceAccountUPN
+
+                    if ($wizardState.BuildValidationEnvironmentConfiguration -and -not ($cachedCredentials | Where-Object { $_.ApplicationId -eq $wizardState.BuildValidationEnvironmentConfiguration.Credentials.ApplicationId -and $_.TenantId -eq $wizardState.BuildValidationEnvironmentConfiguration.Credentials.TenantId })) {
+                        $cachedCredentials += $wizardState.BuildValidationEnvironmentConfiguration.Credentials
+                    }
+                    if ($wizardState.BuildValidationEnvironmentConfiguration -and $cachedServiceAccounts -notcontains $wizardState.BuildValidationEnvironmentConfiguration.ServiceAccountUPN) {
+                        $cachedServiceAccounts += $wizardState.BuildValidationEnvironmentConfiguration.ServiceAccountUPN
+                    }
+
+                    $wizardState.BuildValidationEnabled = $true
                 }
             },
             [pscustomobject]@{
@@ -4304,7 +4374,8 @@ function Invoke-GitHubBranchAwareSetup {
                         'Credential storage'       = $(if ($UseGitHubEnvironments) { 'GitHub environments' } else { 'Prefixed repository variables/secrets' })
                         'Promotion mode'           = $DeploymentPromotionMode
                         'Configured branches'      = [string]$wizardState.BranchStates.Count
-                        'BUILD validation enabled branches' = [string]@($wizardState.BranchStates | Where-Object { $_.BuildValidationEnabled }).Count
+                        'BUILD validation'         = $(if ($wizardState.BuildValidationEnabled) { 'Enabled' } else { 'Disabled' })
+                        'BUILD validation environment' = $(if ($wizardState.BuildValidationEnvironmentConfiguration) { $wizardState.BuildValidationEnvironmentConfiguration.ShortName } else { '<none>' })
                         'Solution source branch'   = $(if ([string]::IsNullOrWhiteSpace($wizardState.SolutionSourceBranch)) { '<none>' } else { $wizardState.SolutionSourceBranch })
                         'Solutions selected'       = [string]$(if ($wizardState.SolutionResult) { @($wizardState.SolutionResult.Solutions).Count } else { 0 })
                     })
@@ -4327,7 +4398,6 @@ function Invoke-GitHubBranchAwareSetup {
                             'Publish mode'            = $publishSummary
                             'DEV environment'         = $(if ($branchState.DevEnvironmentConfiguration) { $branchState.DevEnvironmentConfiguration.ShortName } else { '<none>' })
                             'Deployment environments' = [string]@($branchState.DeploymentEnvironments).Count
-                            'BUILD validation'        = $(if ($branchState.BuildValidationEnabled) { 'Enabled' } else { 'Disabled' })
                         })
                     }
 
@@ -4441,7 +4511,8 @@ function Invoke-GitHubBranchAwareSetup {
                         -Solutions $solutionsForBranchPublish `
                         -DeploymentEnvironments @($branchState.DeploymentEnvironments) `
                         -DeployWorkflowBranchDefinitions $deployDefinitionsForBranchPublish `
-                        -BuildValidationEnabled ([bool]$branchState.BuildValidationEnabled) `
+                        -BuildValidationEnabled ([bool]$wizardState.BuildValidationEnabled) `
+                        -BuildValidationEnvironmentName $(if ($wizardState.BuildValidationEnvironmentConfiguration) { [string]$wizardState.BuildValidationEnvironmentConfiguration.ShortName } else { '' }) `
                         -SkipDeployWorkflow:$isRemovedBranch
             }
 
@@ -4459,6 +4530,8 @@ function Invoke-GitHubBranchAwareSetup {
             BranchStates         = @($wizardState.BranchStates)
             SolutionResult       = $wizardState.SolutionResult
             SolutionSourceBranch = $wizardState.SolutionSourceBranch
+            BuildValidationEnabled = [bool]$wizardState.BuildValidationEnabled
+            BuildValidationEnvironmentConfiguration = $wizardState.BuildValidationEnvironmentConfiguration
             PublishResults       = @($publishResults)
         }
     }
@@ -4905,6 +4978,8 @@ $githubSetupResult = Invoke-GitHubBranchAwareSetup `
 $branchStates = @($githubSetupResult.BranchStates)
 $solutionResult = $githubSetupResult.SolutionResult
 $solutionSourceBranch = $githubSetupResult.SolutionSourceBranch
+$buildValidationEnabled = [bool](Get-OptionalObjectPropertyValue -InputObject $githubSetupResult -PropertyName 'BuildValidationEnabled')
+$buildValidationEnvironmentConfiguration = Get-OptionalObjectPropertyValue -InputObject $githubSetupResult -PropertyName 'BuildValidationEnvironmentConfiguration'
 $repoPublishResults = @($githubSetupResult.PublishResults)
 $allConfiguredEnvironments = @()
 $allDeploymentEnvironments = @()
@@ -4951,6 +5026,29 @@ else {
                 -EnableApprovals:$false
         } | Out-Null
     }
+}
+
+# ─────────────────────────────────────────────────────────────
+Write-Section `
+    -Message "Configure Global BUILD Validation Environment"
+
+if (-not $buildValidationEnabled -or -not $buildValidationEnvironmentConfiguration) {
+    [Spectre.Console.AnsiConsole]::MarkupLine('[yellow]Global BUILD validation is disabled, so BUILD environment credentials will be skipped.[/]')
+}
+else {
+    Write-Host "Applying global BUILD validation environment '$($buildValidationEnvironmentConfiguration.ShortName)'." -ForegroundColor Green
+    Write-Host ""
+
+    Invoke-WithErrorHandling -OperationName 'Applying global BUILD validation environment configuration' -AllowSkip -ScriptBlock {
+        Apply-GitHubEnvironmentConfiguration `
+            -EnvironmentConfiguration $buildValidationEnvironmentConfiguration `
+            -TenantId $TenantId `
+            -RepoOwner $repoOwner `
+            -RepoName $repoName `
+            -RepoFullName $repoFullName `
+            -UseGitHubEnvironments $useGitHubEnvironments `
+            -EnableApprovals:$false
+    } -StatusMessage 'Applying global BUILD validation environment configuration...' -CaptureOutputInPanel | Out-Null
 }
 
 # ─────────────────────────────────────────────────────────────
@@ -5004,6 +5102,8 @@ Show-SetupCompletionScreen `
         'Repository publish'      = (Get-GitHubPublishSummaryText -PublishResults $repoPublishResults)
         'Promotion mode'          = $deploymentPromotionMode
         'Credential storage'      = $(if ($useGitHubEnvironments) { 'GitHub environments' } else { 'Prefixed repository variables/secrets' })
+        'BUILD validation'        = $(if ($buildValidationEnabled) { 'Enabled' } else { 'Disabled' })
+        'BUILD validation environment' = $(if ($buildValidationEnvironmentConfiguration) { $buildValidationEnvironmentConfiguration.ShortName } else { '<none>' })
         'Configured environments' = [string]$allConfiguredEnvironments.Count
     }) `
     -NextStepLinks @(

--- a/setup-github.ps1
+++ b/setup-github.ps1
@@ -3025,6 +3025,11 @@ function Update-DeployWorkflowInRepoClone {
 
     $deployFilePath = Join-Path $RepoRoot ".github/workflows/DEPLOY-$Branch.yml"
 
+    $deployDirectory = Split-Path -Parent $deployFilePath
+    if (-not (Test-Path -LiteralPath $deployDirectory)) {
+        New-Item -ItemType Directory -Path $deployDirectory -Force | Out-Null
+    }
+
     if (-not $DeploymentEnvironments -or $DeploymentEnvironments.Count -eq 0) {
         if (Test-Path -LiteralPath $deployFilePath) {
             Remove-Item -LiteralPath $deployFilePath -Force
@@ -3035,10 +3040,6 @@ function Update-DeployWorkflowInRepoClone {
         }
 
         return
-    }
-
-    if (-not (Test-Path -LiteralPath $deployFilePath)) {
-        throw "Deploy workflow file not found: $deployFilePath"
     }
 
     $usesRef = "$SharedWorkflowRepository/.github/workflows/deploy.yml@$SharedWorkflowRef"
@@ -3406,15 +3407,6 @@ function Publish-GitHubBranchSetupChanges {
 
                 if ([string]::IsNullOrWhiteSpace($workflowBranchName)) {
                     continue
-                }
-
-                if ($workflowBranchName -ne $ConfiguredBranch -and $workflowDeploymentEnvironments.Count -gt 0) {
-                    Copy-WorkflowTemplatesToRepo `
-                        -SourceRoot $CopyRoot `
-                        -TargetRoot $RepoRoot `
-                        -Branch $workflowBranchName `
-                        -SharedWorkflowRepository $SharedWorkflowRepository `
-                        -SharedWorkflowRef $SharedWorkflowReference
                 }
 
                 Update-DeployWorkflowInRepoClone `

--- a/setup-github.ps1
+++ b/setup-github.ps1
@@ -3003,6 +3003,7 @@ $environmentBlock    uses: $SharedWorkflowRepository/.github/workflows/build.yml
     permissions:
       contents: write
       actions: write
+            id-token: write
 "@
 
     Set-Content -LiteralPath $buildWorkflowPath -Value $newContent.TrimStart("`r", "`n") -NoNewline

--- a/setup-github.ps1
+++ b/setup-github.ps1
@@ -2925,16 +2925,25 @@ function Update-AlmConfigInRepoClone {
     #>
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory)][array]$Solutions,
+        [Parameter()][AllowNull()][array]$Solutions,
         [Parameter(Mandatory)][bool]$BuildValidationEnabled,
         [Parameter(Mandatory)][string]$RepoRoot
     )
 
     $configPath = Join-Path $RepoRoot 'alm-config.psd1'
     $templatePath = if ($PSScriptRoot) { Join-Path $PSScriptRoot 'copy-to-your-repo\alm-config.psd1' } else { $null }
-    [void](Set-AlmConfigSolutionsInFile -ConfigPath $configPath -Solutions $Solutions -CreateIfMissing -TemplatePath $templatePath)
+
+    $effectiveSolutions = @()
+    if ($null -ne $Solutions) {
+        $effectiveSolutions = @($Solutions)
+        [void](Set-AlmConfigSolutionsInFile -ConfigPath $configPath -Solutions $effectiveSolutions -CreateIfMissing -TemplatePath $templatePath)
+    }
+    else {
+        Write-Host 'Skipping solution list updates in alm-config.psd1 because solution selection was not run.' -ForegroundColor Yellow
+    }
+
     [void](Set-AlmConfigSolutionCheckEnabledInFile -ConfigPath $configPath -Enabled $BuildValidationEnabled -CreateIfMissing -TemplatePath $templatePath)
-    Write-Host "Updated alm-config.psd1 with $($Solutions.Count) solution(s); solutionCheck.enabled=$BuildValidationEnabled."
+    Write-Host "Updated alm-config.psd1 with $($effectiveSolutions.Count) solution(s); solutionCheck.enabled=$BuildValidationEnabled."
 }
 
 function Update-BuildWorkflowInRepoClone {
@@ -3282,7 +3291,7 @@ function Publish-GitHubBranchSetupChanges {
         [Parameter(Mandatory)][string]$SharedWorkflowRepository,
         [Parameter(Mandatory)][string]$SharedWorkflowReference,
         [Parameter(Mandatory)][string]$PromotionMode,
-        [Parameter()][array]$Solutions,
+        [Parameter()][AllowNull()][array]$Solutions,
         [Parameter()][array]$DeploymentEnvironments,
         [Parameter()][array]$DeployWorkflowBranchDefinitions,
         [Parameter()][bool]$BuildValidationEnabled = $false,
@@ -3377,8 +3386,7 @@ function Publish-GitHubBranchSetupChanges {
             -SharedWorkflowRef $SharedWorkflowReference `
             -SkipDeployWorkflow:$SkipDeployWorkflow
 
-        $effectiveSolutions = if ($Solutions) { @($Solutions) } else { @() }
-        Update-AlmConfigInRepoClone -Solutions $effectiveSolutions -BuildValidationEnabled $BuildValidationEnabled -RepoRoot $RepoRoot
+        Update-AlmConfigInRepoClone -Solutions $Solutions -BuildValidationEnabled $BuildValidationEnabled -RepoRoot $RepoRoot
 
         $buildEnvironmentName = if ($BuildValidationEnabled) { [string]$BuildValidationEnvironmentName } else { '' }
         Update-BuildWorkflowInRepoClone `

--- a/setup-github.ps1
+++ b/setup-github.ps1
@@ -2962,16 +2962,6 @@ function Update-BuildWorkflowInRepoClone {
     }
 
     $escapedBuildEnvironmentName = ([string]$BuildEnvironmentName).Replace("'", "''")
-    $environmentBlock = if ($BuildValidationEnabled -and -not [string]::IsNullOrWhiteSpace($BuildEnvironmentName)) {
-@"
-        environment:
-            name: $escapedBuildEnvironmentName
-            deployment: false
-"@
-    }
-    else {
-        ''
-    }
 
     $environmentInput = if ($BuildValidationEnabled -and -not [string]::IsNullOrWhiteSpace($BuildEnvironmentName)) {
         $escapedBuildEnvironmentName
@@ -3002,7 +2992,6 @@ on:
 
 jobs:
     build:
-$environmentBlock
         uses: $SharedWorkflowRepository/.github/workflows/build.yml@$SharedWorkflowReference
         with:
             build-name: `${{ format('{0}-{1}-{2}-{3}', github.event.repository.name, (github.event_name == 'repository_dispatch' && github.event.client_payload.branch) || github.ref_name, (github.event_name == 'repository_dispatch' && github.event.client_payload.exported_at) || github.event.head_commit.timestamp || github.event.repository.updated_at || github.run_id, github.run_number) }}

--- a/setup-github.ps1
+++ b/setup-github.ps1
@@ -3532,6 +3532,7 @@ function Invoke-GitHubBranchAwareSetup {
             SolutionSourceBranch = $null
             BranchEnvironmentMappingCompleted = $false
             BuildValidationEnabled = [bool](Get-OptionalObjectPropertyValue -InputObject $ExistingSetupState -PropertyName 'BuildValidationEnabled')
+            BuildValidationEnvironmentName = [string](Get-OptionalObjectPropertyValue -InputObject $ExistingSetupState -PropertyName 'BuildValidationEnvironmentName')
             BuildValidationEnvironmentConfiguration = (Get-OptionalObjectPropertyValue -InputObject $ExistingSetupState -PropertyName 'ExistingBuildValidationEnvironment')
         }
 
@@ -4248,6 +4249,7 @@ function Invoke-GitHubBranchAwareSetup {
 
                     if (-not $enableBuildValidation) {
                         $wizardState.BuildValidationEnabled = $false
+                        $wizardState.BuildValidationEnvironmentName = ''
                         $wizardState.BuildValidationEnvironmentConfiguration = $null
                         return
                     }
@@ -4255,6 +4257,9 @@ function Invoke-GitHubBranchAwareSetup {
                     $existingBuildValidationEnvironment = $wizardState.BuildValidationEnvironmentConfiguration
                     $existingBuildValidationEnvironmentUrl = [string](Get-OptionalObjectPropertyValue -InputObject $existingBuildValidationEnvironment -PropertyName 'Url')
                     $existingBuildValidationEnvironmentName = [string](Get-OptionalObjectPropertyValue -InputObject $existingBuildValidationEnvironment -PropertyName 'ShortName')
+                    if ([string]::IsNullOrWhiteSpace($existingBuildValidationEnvironmentName)) {
+                        $existingBuildValidationEnvironmentName = [string](Get-OptionalObjectPropertyValue -InputObject $wizardState -PropertyName 'BuildValidationEnvironmentName')
+                    }
                     $existingBuildValidationEnvironmentCredential = Get-OptionalObjectPropertyValue -InputObject $existingBuildValidationEnvironment -PropertyName 'Credentials'
                     $existingBuildValidationServiceAccountUPN = [string](Get-OptionalObjectPropertyValue -InputObject $existingBuildValidationEnvironment -PropertyName 'ServiceAccountUPN')
 
@@ -4276,6 +4281,8 @@ function Invoke-GitHubBranchAwareSetup {
                         throw 'A GitHub environment name is required for global BUILD validation.'
                     }
 
+                    $wizardState.BuildValidationEnvironmentName = $buildValidationEnvironmentName
+
                     $wizardState.BuildValidationEnvironmentConfiguration = Get-GitHubEnvironmentConfiguration `
                         -EnvironmentName $buildValidationEnvironmentName `
                         -EnvironmentUrl (ConvertTo-NormalizedEnvironmentUrl -Url $selectedBuildEnvironment.Endpoints['WebApplication']) `
@@ -4292,6 +4299,10 @@ function Invoke-GitHubBranchAwareSetup {
                     }
                     if ($wizardState.BuildValidationEnvironmentConfiguration -and $cachedServiceAccounts -notcontains $wizardState.BuildValidationEnvironmentConfiguration.ServiceAccountUPN) {
                         $cachedServiceAccounts += $wizardState.BuildValidationEnvironmentConfiguration.ServiceAccountUPN
+                    }
+
+                    if ($wizardState.BuildValidationEnvironmentConfiguration -and -not [string]::IsNullOrWhiteSpace([string]$wizardState.BuildValidationEnvironmentConfiguration.ShortName)) {
+                        $wizardState.BuildValidationEnvironmentName = [string]$wizardState.BuildValidationEnvironmentConfiguration.ShortName
                     }
 
                     $wizardState.BuildValidationEnabled = $true
@@ -4374,7 +4385,7 @@ function Invoke-GitHubBranchAwareSetup {
                         'Promotion mode'           = $DeploymentPromotionMode
                         'Configured branches'      = [string]$wizardState.BranchStates.Count
                         'BUILD validation'         = $(if ($wizardState.BuildValidationEnabled) { 'Enabled' } else { 'Disabled' })
-                        'BUILD validation environment' = $(if ($wizardState.BuildValidationEnvironmentConfiguration) { $wizardState.BuildValidationEnvironmentConfiguration.ShortName } else { '<none>' })
+                        'BUILD validation environment' = $(if (-not [string]::IsNullOrWhiteSpace([string]$wizardState.BuildValidationEnvironmentName)) { [string]$wizardState.BuildValidationEnvironmentName } elseif ($wizardState.BuildValidationEnvironmentConfiguration) { $wizardState.BuildValidationEnvironmentConfiguration.ShortName } else { '<none>' })
                         'Solution source branch'   = $(if ([string]::IsNullOrWhiteSpace($wizardState.SolutionSourceBranch)) { '<none>' } else { $wizardState.SolutionSourceBranch })
                         'Solutions selected'       = [string]$(if ($wizardState.SolutionResult) { @($wizardState.SolutionResult.Solutions).Count } else { 0 })
                     })
@@ -4464,6 +4475,14 @@ function Invoke-GitHubBranchAwareSetup {
             $publishBranchStates += $removedBranchState
         }
 
+        $buildValidationEnvironmentNameForPublish = ''
+        if (-not [string]::IsNullOrWhiteSpace([string]$wizardState.BuildValidationEnvironmentName)) {
+            $buildValidationEnvironmentNameForPublish = [string]$wizardState.BuildValidationEnvironmentName
+        }
+        elseif ($wizardState.BuildValidationEnvironmentConfiguration -and -not [string]::IsNullOrWhiteSpace([string]$wizardState.BuildValidationEnvironmentConfiguration.ShortName)) {
+            $buildValidationEnvironmentNameForPublish = [string]$wizardState.BuildValidationEnvironmentConfiguration.ShortName
+        }
+
         $defaultBranchDeployWorkflowDefinitions = @()
         foreach ($configuredBranchState in @($wizardState.BranchStates)) {
             $defaultBranchDeployWorkflowDefinitions += [pscustomobject]@{
@@ -4511,7 +4530,7 @@ function Invoke-GitHubBranchAwareSetup {
                         -DeploymentEnvironments @($branchState.DeploymentEnvironments) `
                         -DeployWorkflowBranchDefinitions $deployDefinitionsForBranchPublish `
                         -BuildValidationEnabled ([bool]$wizardState.BuildValidationEnabled) `
-                        -BuildValidationEnvironmentName $(if ($wizardState.BuildValidationEnvironmentConfiguration) { [string]$wizardState.BuildValidationEnvironmentConfiguration.ShortName } else { '' }) `
+                        -BuildValidationEnvironmentName $buildValidationEnvironmentNameForPublish `
                         -SkipDeployWorkflow:$isRemovedBranch
             }
 
@@ -4530,6 +4549,7 @@ function Invoke-GitHubBranchAwareSetup {
             SolutionResult       = $wizardState.SolutionResult
             SolutionSourceBranch = $wizardState.SolutionSourceBranch
             BuildValidationEnabled = [bool]$wizardState.BuildValidationEnabled
+            BuildValidationEnvironmentName = [string]$wizardState.BuildValidationEnvironmentName
             BuildValidationEnvironmentConfiguration = $wizardState.BuildValidationEnvironmentConfiguration
             PublishResults       = @($publishResults)
         }

--- a/setup-github.ps1
+++ b/setup-github.ps1
@@ -2964,9 +2964,9 @@ function Update-BuildWorkflowInRepoClone {
     $escapedBuildEnvironmentName = ([string]$BuildEnvironmentName).Replace("'", "''")
     $environmentBlock = if ($BuildValidationEnabled -and -not [string]::IsNullOrWhiteSpace($BuildEnvironmentName)) {
 @"
-    environment:
-      name: $escapedBuildEnvironmentName
-      deployment: false
+        environment:
+            name: $escapedBuildEnvironmentName
+            deployment: false
 "@
     }
     else {
@@ -2980,7 +2980,7 @@ function Update-BuildWorkflowInRepoClone {
         ''
     }
 
-    $newContent = @"
+        $newContent = @"
 name: BUILD
 
 # Triggers on every push to any branch.
@@ -2992,26 +2992,27 @@ name: BUILD
 run-name: `${{ format('{0}-{1}-{2}-{3}', github.event.repository.name, (github.event_name == 'repository_dispatch' && github.event.client_payload.branch) || github.ref_name, (github.event_name == 'repository_dispatch' && github.event.client_payload.exported_at) || github.event.head_commit.timestamp || github.event.repository.updated_at || github.run_id, github.run_number) }}
 
 on:
-  push:
-    branches:
-      - '**'
-  workflow_dispatch:
-  repository_dispatch:
-    types:
-      - alm4dataverse-export-build
+    push:
+        branches:
+            - '**'
+    workflow_dispatch:
+    repository_dispatch:
+        types:
+            - alm4dataverse-export-build
 
 jobs:
-  build:
-$environmentBlock    uses: $SharedWorkflowRepository/.github/workflows/build.yml@$SharedWorkflowReference
-    with:
-      build-name: `${{ format('{0}-{1}-{2}-{3}', github.event.repository.name, (github.event_name == 'repository_dispatch' && github.event.client_payload.branch) || github.ref_name, (github.event_name == 'repository_dispatch' && github.event.client_payload.exported_at) || github.event.head_commit.timestamp || github.event.repository.updated_at || github.run_id, github.run_number) }}
-      source-branch: `${{ (github.event_name == 'repository_dispatch' && github.event.client_payload.branch) || github.ref_name }}
-      source-ref: `${{ (github.event_name == 'repository_dispatch' && github.event.client_payload.sha) || github.sha }}
-      environment-name: '$environmentInput'
-      timeout-minutes: 360
-    permissions:
-      contents: write
-      actions: write
+    build:
+$environmentBlock
+        uses: $SharedWorkflowRepository/.github/workflows/build.yml@$SharedWorkflowReference
+        with:
+            build-name: `${{ format('{0}-{1}-{2}-{3}', github.event.repository.name, (github.event_name == 'repository_dispatch' && github.event.client_payload.branch) || github.ref_name, (github.event_name == 'repository_dispatch' && github.event.client_payload.exported_at) || github.event.head_commit.timestamp || github.event.repository.updated_at || github.run_id, github.run_number) }}
+            source-branch: `${{ (github.event_name == 'repository_dispatch' && github.event.client_payload.branch) || github.ref_name }}
+            source-ref: `${{ (github.event_name == 'repository_dispatch' && github.event.client_payload.sha) || github.sha }}
+            environment-name: '$environmentInput'
+            timeout-minutes: 360
+        permissions:
+            contents: write
+            actions: write
             id-token: write
 "@
 

--- a/setup-github.ps1
+++ b/setup-github.ps1
@@ -1024,6 +1024,7 @@ function New-GitHubBranchSetupState {
         [Parameter(Mandatory)][string]$BranchName,
         [Parameter()][object]$ExistingDevEnvironment,
         [Parameter()][array]$DeploymentEnvironments,
+        [Parameter()][bool]$BuildValidationEnabled = $false,
         [Parameter()][object]$PublishPlan
     )
 
@@ -1034,6 +1035,7 @@ function New-GitHubBranchSetupState {
         ExistingDevEnvironment      = $ExistingDevEnvironment
         DevEnvironmentConfiguration = $null
         DeploymentEnvironments      = $normalizedDeploymentEnvironments
+        BuildValidationEnabled      = $BuildValidationEnabled
         PublishPlan                 = $PublishPlan
     }
 }
@@ -2845,13 +2847,86 @@ function Update-AlmConfigInRepoClone {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)][array]$Solutions,
+        [Parameter(Mandatory)][bool]$BuildValidationEnabled,
         [Parameter(Mandatory)][string]$RepoRoot
     )
 
     $configPath = Join-Path $RepoRoot 'alm-config.psd1'
     $templatePath = if ($PSScriptRoot) { Join-Path $PSScriptRoot 'copy-to-your-repo\alm-config.psd1' } else { $null }
     [void](Set-AlmConfigSolutionsInFile -ConfigPath $configPath -Solutions $Solutions -CreateIfMissing -TemplatePath $templatePath)
-    Write-Host "Updated alm-config.psd1 with $($Solutions.Count) solution(s)."
+    [void](Set-AlmConfigSolutionCheckEnabledInFile -ConfigPath $configPath -Enabled $BuildValidationEnabled -CreateIfMissing -TemplatePath $templatePath)
+    Write-Host "Updated alm-config.psd1 with $($Solutions.Count) solution(s); solutionCheck.enabled=$BuildValidationEnabled."
+}
+
+function Update-BuildWorkflowInRepoClone {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$RepoRoot,
+        [Parameter(Mandatory)][string]$SharedWorkflowRepository,
+        [Parameter(Mandatory)][string]$SharedWorkflowReference,
+        [Parameter(Mandatory)][string]$BuildEnvironmentName,
+        [Parameter(Mandatory)][bool]$BuildValidationEnabled
+    )
+
+    $buildWorkflowPath = Join-Path $RepoRoot '.github/workflows/BUILD.yml'
+    if (-not (Test-Path -LiteralPath $buildWorkflowPath)) {
+        throw "Build workflow file not found: $buildWorkflowPath"
+    }
+
+    $escapedBuildEnvironmentName = ([string]$BuildEnvironmentName).Replace("'", "''")
+    $environmentBlock = if ($BuildValidationEnabled -and -not [string]::IsNullOrWhiteSpace($BuildEnvironmentName)) {
+@"
+    environment:
+      name: $escapedBuildEnvironmentName
+      deployment: false
+"@
+    }
+    else {
+        ''
+    }
+
+    $environmentInput = if ($BuildValidationEnabled -and -not [string]::IsNullOrWhiteSpace($BuildEnvironmentName)) {
+        $escapedBuildEnvironmentName
+    }
+    else {
+        ''
+    }
+
+    $newContent = @"
+name: BUILD
+
+# Triggers on every push to any branch.
+# Also supports manual runs and repository_dispatch from EXPORT.
+# Packs Dataverse solutions into deployable artifacts and tags the source commit.
+#
+# See docs/usage/building-releases.md and docs/setup/github-setup.md
+
+run-name: `${{ format('{0}-{1}-{2}-{3}', github.event.repository.name, (github.event_name == 'repository_dispatch' && github.event.client_payload.branch) || github.ref_name, (github.event_name == 'repository_dispatch' && github.event.client_payload.exported_at) || github.event.head_commit.timestamp || github.event.repository.updated_at || github.run_id, github.run_number) }}
+
+on:
+  push:
+    branches:
+      - '**'
+  workflow_dispatch:
+  repository_dispatch:
+    types:
+      - alm4dataverse-export-build
+
+jobs:
+  build:
+$environmentBlock    uses: $SharedWorkflowRepository/.github/workflows/build.yml@$SharedWorkflowReference
+    with:
+      build-name: `${{ format('{0}-{1}-{2}-{3}', github.event.repository.name, (github.event_name == 'repository_dispatch' && github.event.client_payload.branch) || github.ref_name, (github.event_name == 'repository_dispatch' && github.event.client_payload.exported_at) || github.event.head_commit.timestamp || github.event.repository.updated_at || github.run_id, github.run_number) }}
+      source-branch: `${{ (github.event_name == 'repository_dispatch' && github.event.client_payload.branch) || github.ref_name }}
+      source-ref: `${{ (github.event_name == 'repository_dispatch' && github.event.client_payload.sha) || github.sha }}
+      environment-name: '$environmentInput'
+      timeout-minutes: 360
+    permissions:
+      contents: write
+      actions: write
+"@
+
+    Set-Content -LiteralPath $buildWorkflowPath -Value $newContent.TrimStart("`r", "`n") -NoNewline
 }
 
 function Update-DeployWorkflowInRepoClone {
@@ -3130,6 +3205,7 @@ function Publish-GitHubBranchSetupChanges {
         [Parameter()][array]$Solutions,
         [Parameter()][array]$DeploymentEnvironments,
         [Parameter()][array]$DeployWorkflowBranchDefinitions,
+        [Parameter()][bool]$BuildValidationEnabled = $false,
         [Parameter()][switch]$SkipDeployWorkflow
     )
 
@@ -3220,9 +3296,16 @@ function Publish-GitHubBranchSetupChanges {
             -SharedWorkflowRef $SharedWorkflowReference `
             -SkipDeployWorkflow:$SkipDeployWorkflow
 
-        if ($Solutions) {
-            Update-AlmConfigInRepoClone -Solutions @($Solutions) -RepoRoot $RepoRoot
-        }
+        $effectiveSolutions = if ($Solutions) { @($Solutions) } else { @() }
+        Update-AlmConfigInRepoClone -Solutions $effectiveSolutions -BuildValidationEnabled $BuildValidationEnabled -RepoRoot $RepoRoot
+
+        $buildEnvironmentName = if ($BuildValidationEnabled) { "Dev-$ConfiguredBranch" } else { '' }
+        Update-BuildWorkflowInRepoClone `
+            -RepoRoot $RepoRoot `
+            -SharedWorkflowRepository $SharedWorkflowRepository `
+            -SharedWorkflowReference $SharedWorkflowReference `
+            -BuildEnvironmentName $buildEnvironmentName `
+            -BuildValidationEnabled $BuildValidationEnabled
 
         if (-not $SkipDeployWorkflow) {
             $effectiveDeployWorkflowDefinitions = @()
@@ -3381,6 +3464,7 @@ function Invoke-GitHubBranchAwareSetup {
                             DevEnvironmentConfiguration = $_.DevEnvironmentConfiguration
                             ExistingDevEnvironment      = $_.ExistingDevEnvironment
                             Environments                = @($_.DeploymentEnvironments)
+                            BuildValidationEnabled      = [bool]$_.BuildValidationEnabled
                         }
                     })
 
@@ -3642,6 +3726,9 @@ function Invoke-GitHubBranchAwareSetup {
                             $existingBranchState = $existingStateByBranch[$branchKey]
                             $existingBranchState.DevEnvironmentConfiguration = $selectedBranchMapping.DevEnvironmentConfiguration
                             $existingBranchState.DeploymentEnvironments = @($selectedBranchMapping.Environments)
+                            if ($selectedBranchMapping.PSObject.Properties.Name -contains 'BuildValidationEnabled') {
+                                $existingBranchState.BuildValidationEnabled = [bool]$selectedBranchMapping.BuildValidationEnabled
+                            }
                             $updatedBranchStates += $existingBranchState
                             continue
                         }
@@ -3656,6 +3743,9 @@ function Invoke-GitHubBranchAwareSetup {
                         $newBranchState = New-GitHubBranchSetupState -BranchName $branchName -ExistingDevEnvironment $existingDevEnvironment -DeploymentEnvironments @()
                         $newBranchState.DevEnvironmentConfiguration = $selectedBranchMapping.DevEnvironmentConfiguration
                         $newBranchState.DeploymentEnvironments = @($selectedBranchMapping.Environments)
+                        if ($selectedBranchMapping.PSObject.Properties.Name -contains 'BuildValidationEnabled') {
+                            $newBranchState.BuildValidationEnabled = [bool]$selectedBranchMapping.BuildValidationEnabled
+                        }
                         $updatedBranchStates += $newBranchState
                     }
 
@@ -3704,6 +3794,9 @@ function Invoke-GitHubBranchAwareSetup {
 
                         $existingBranchState.DevEnvironmentConfiguration = $mappedBranch.DevEnvironmentConfiguration
                         $existingBranchState.DeploymentEnvironments = @($mappedBranch.Environments)
+                        if ($mappedBranch.PSObject.Properties.Name -contains 'BuildValidationEnabled') {
+                            $existingBranchState.BuildValidationEnabled = [bool]$mappedBranch.BuildValidationEnabled
+                        }
                         $existingBranchState
                     })
 
@@ -4066,6 +4159,76 @@ function Invoke-GitHubBranchAwareSetup {
                 }
             },
             [pscustomobject]@{
+                Name = 'Configure BUILD validation'
+                Action = {
+                    Write-Section `
+                        -Message 'Configure solution validation during BUILD'
+                    Write-SetupGuidance -Lines @(
+                        'When enabled for a branch, BUILD associates with that branch''s DEV environment and runs Dataverse connect before build/validation.',
+                        'If no DEV environment is configured yet, setup will prompt for it now using the same environment/auth flow as EXPORT.'
+                    ) -DocRelativePath 'docs/usage/building-releases.md' -Ref $ALM4DataverseRef -Header 'Build validation guidance'
+
+                    foreach ($branchState in @($wizardState.BranchStates)) {
+                        $branchName = [string]$branchState.BranchName
+                        $enablePrompt = "Enable solution validation during BUILD for branch '$branchName'?"
+                        $enableBuildValidation = if ([bool]$branchState.BuildValidationEnabled) {
+                            Read-YesNo -Prompt $enablePrompt
+                        }
+                        else {
+                            Read-YesNo -Prompt $enablePrompt -DefaultNo
+                        }
+
+                        if (-not $enableBuildValidation) {
+                            $branchState.BuildValidationEnabled = $false
+                            continue
+                        }
+
+                        if (-not $branchState.DevEnvironmentConfiguration -and $branchState.ExistingDevEnvironment) {
+                            $branchState.DevEnvironmentConfiguration = $branchState.ExistingDevEnvironment
+                        }
+
+                        if (-not $branchState.DevEnvironmentConfiguration) {
+                            Write-Section `
+                                -Message "BUILD validation requires a DEV environment for branch '$branchName'"
+
+                            if ($UseGitHubEnvironments) {
+                                Write-Host "Preparing GitHub environment 'Dev-$branchName' for BUILD validation." -ForegroundColor Green
+                            }
+                            else {
+                                Write-Host "Preparing prefixed repo-level credentials for DEV environment 'Dev-$branchName' (BUILD validation)." -ForegroundColor Green
+                            }
+                            Write-Host ''
+
+                            $devEnvSelection = Select-DataverseEnvironment -Prompt "Select the DEV Dataverse environment for branch '$branchName'"
+                            if (-not $devEnvSelection) {
+                                throw "BUILD validation was enabled for branch '$branchName', but no DEV environment was selected."
+                            }
+
+                            $devEnvUrl = ConvertTo-NormalizedEnvironmentUrl -Url $devEnvSelection.Endpoints['WebApplication']
+                            $devEnvFriendlyName = $devEnvSelection.FriendlyName
+
+                            $branchState.DevEnvironmentConfiguration = Get-GitHubEnvironmentConfiguration `
+                                -EnvironmentName "Dev-$branchName" `
+                                -EnvironmentUrl $devEnvUrl `
+                                -FriendlyName $devEnvFriendlyName `
+                                -ExistingCredentials $cachedCredentials `
+                                -ExistingServiceAccounts $cachedServiceAccounts `
+                                -TenantId $TenantId `
+                                -RepoName $RepoName
+
+                            if ($branchState.DevEnvironmentConfiguration -and -not ($cachedCredentials | Where-Object { $_.ApplicationId -eq $branchState.DevEnvironmentConfiguration.Credentials.ApplicationId -and $_.TenantId -eq $branchState.DevEnvironmentConfiguration.Credentials.TenantId })) {
+                                $cachedCredentials += $branchState.DevEnvironmentConfiguration.Credentials
+                            }
+                            if ($branchState.DevEnvironmentConfiguration -and $cachedServiceAccounts -notcontains $branchState.DevEnvironmentConfiguration.ServiceAccountUPN) {
+                                $cachedServiceAccounts += $branchState.DevEnvironmentConfiguration.ServiceAccountUPN
+                            }
+                        }
+
+                        $branchState.BuildValidationEnabled = $true
+                    }
+                }
+            },
+            [pscustomobject]@{
                 Name = 'Configure solutions'
                 Action = {
                     Write-Section `
@@ -4141,6 +4304,7 @@ function Invoke-GitHubBranchAwareSetup {
                         'Credential storage'       = $(if ($UseGitHubEnvironments) { 'GitHub environments' } else { 'Prefixed repository variables/secrets' })
                         'Promotion mode'           = $DeploymentPromotionMode
                         'Configured branches'      = [string]$wizardState.BranchStates.Count
+                        'BUILD validation enabled branches' = [string]@($wizardState.BranchStates | Where-Object { $_.BuildValidationEnabled }).Count
                         'Solution source branch'   = $(if ([string]::IsNullOrWhiteSpace($wizardState.SolutionSourceBranch)) { '<none>' } else { $wizardState.SolutionSourceBranch })
                         'Solutions selected'       = [string]$(if ($wizardState.SolutionResult) { @($wizardState.SolutionResult.Solutions).Count } else { 0 })
                     })
@@ -4163,6 +4327,7 @@ function Invoke-GitHubBranchAwareSetup {
                             'Publish mode'            = $publishSummary
                             'DEV environment'         = $(if ($branchState.DevEnvironmentConfiguration) { $branchState.DevEnvironmentConfiguration.ShortName } else { '<none>' })
                             'Deployment environments' = [string]@($branchState.DeploymentEnvironments).Count
+                            'BUILD validation'        = $(if ($branchState.BuildValidationEnabled) { 'Enabled' } else { 'Disabled' })
                         })
                     }
 
@@ -4276,6 +4441,7 @@ function Invoke-GitHubBranchAwareSetup {
                         -Solutions $solutionsForBranchPublish `
                         -DeploymentEnvironments @($branchState.DeploymentEnvironments) `
                         -DeployWorkflowBranchDefinitions $deployDefinitionsForBranchPublish `
+                        -BuildValidationEnabled ([bool]$branchState.BuildValidationEnabled) `
                         -SkipDeployWorkflow:$isRemovedBranch
             }
 


### PR DESCRIPTION
## Release Notes

This pull request introduces support for automated solution validation using the Power Platform ALM Checker (`pac solution check`) during the `BUILD` process, with flexible configuration at both the global and per-solution level. See the config file for more details.

## Changes

**Solution Validation Integration**

* Added support for running `pac solution check` in the `BUILD` workflow, including configuration for region, rule set, severity threshold, excluded files, and rule overrides, with the ability to enable/disable checks globally or per solution. (`alm-config-defaults.psd1`, `copy-to-your-repo/alm-config.psd1`, [[1]](diffhunk://#diff-979ba032b7de5a9b19cf801dfa8d7a5a1ca0881ad92f3b2a0fe24181a6dc5729R13-R39) [[2]](diffhunk://#diff-a1566ec234d4b0c7d2df79fb46e6db159310d4120f96fd26a2ee6d850727c53aR27-R46) [[3]](diffhunk://#diff-a1566ec234d4b0c7d2df79fb46e6db159310d4120f96fd26a2ee6d850727c53aR128-R154)
* Updated documentation to describe new solution check settings, configuration options, and artifact outputs, with detailed examples and authentication behavior. (`docs/config/alm-config.md`, [[1]](diffhunk://#diff-5689fe80e714e941b36c98a7621b7bb0a9e96ccf6b43f05e3d8db8f8384f3760L3-R3) [[2]](diffhunk://#diff-5689fe80e714e941b36c98a7621b7bb0a9e96ccf6b43f05e3d8db8f8384f3760R29) [[3]](diffhunk://#diff-5689fe80e714e941b36c98a7621b7bb0a9e96ccf6b43f05e3d8db8f8384f3760R197-R281); `docs/setup/azdo-manual-setup.md`, [[4]](diffhunk://#diff-c70919b48e2e7c3328c1c49d88fd77a69512c2ce6d12740d4dbda559a0d90682R409-R427); `docs/setup/github-setup.md`, [[5]](diffhunk://#diff-be29d586adb4db49707640baac202fc7973d399c78a5a9daf4686562f67a211bR29-R30)

**Workflow and Pipeline Enhancements**

* Enhanced the GitHub Actions `build.yml` workflow to support an optional `environment-name` input, improved environment variable and secret resolution (including prefix handling), and added OIDC token support for workload identity federation. (`.github/workflows/build.yml`, [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R31-R35) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R53-R67) [[3]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R165-R367)
* Updated build steps to connect to Dataverse and run solution validation when enabled, including additional artifact uploads for solution check reports. (`.github/workflows/build.yml`, [.github/workflows/build.ymlR165-R367](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R165-R367))

**Template and Setup Improvements**

* Modified reusable workflow and pipeline templates to pass through environment and solution check parameters. (`copy-to-your-repo/.github/workflows/BUILD.yml`, [[1]](diffhunk://#diff-43d75de2cac66ce61b0dc545c67b37543d2bb12c3a6cc9dbe4a8eea986fffa6fR27-R32); `copy-to-your-repo/pipelines/BUILD.yml`, [[2]](diffhunk://#diff-13bd0ffbe6ba7ed870b93e41c48253e7a788e49fcb8f1a82f3624645ac17a7e4R14-R16)
* Improved automated setup scripts to prompt for solution validation configuration and wire up environments accordingly. (`docs/setup/azdo-automated-setup.md`, [docs/setup/azdo-automated-setup.mdR87](diffhunk://#diff-5905a51a37c7edcd864a4598c59e92ea1bdbc8b2656ed186d3e7feabd59e6955R87))